### PR TITLE
Fix crew history cell colors

### DIFF
--- a/src/components/CrewHistoryView.tsx
+++ b/src/components/CrewHistoryView.tsx
@@ -318,7 +318,8 @@ export default function CrewHistoryView({
       (d: any) => d.month === month && d.person_id === personId && d.segment === seg,
     );
     const role = roles.find((r: any) => r.id === def?.role_id);
-    const color = role ? role.group_color : undefined;
+    const group = role ? groups.find((g: any) => g.id === role.group_id) : null;
+    const color = group?.custom_color || undefined;
     if (month === nextMonth || editPast) {
       return {
         content: (


### PR DESCRIPTION
## Summary
- ensure crew history cells use group custom colors

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Cannot find package '@vitejs/plugin-react')


------
https://chatgpt.com/codex/tasks/task_e_689ff7b4f7a883229f278e24c1d31b24