### PR TITLE
Improve profile dialog accessibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-grid-layout": "^1.3.4",
     "sql.js": "^1.9.0",
     "@fluentui/react-components": "^9.53.4",
-    "@fluentui/react-icons": "^2.0.231"
+    "@fluentui/react-icons": "^2.0.231",
+    "@fluentui/react-motion": "^9.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.0",

--- a/src/components/PersonProfileModal.tsx
+++ b/src/components/PersonProfileModal.tsx
@@ -10,7 +10,7 @@ import {
   makeStyles,
   tokens,
 } from "@fluentui/react-components";
-import { Presence, Motion, animations } from "@fluentui/react-motion";
+import { Motion, animations } from "@fluentui/react-motion";
 import { Dismiss24Regular } from "@fluentui/react-icons";
 
 interface PersonProfileModalProps {
@@ -68,9 +68,8 @@ export default function PersonProfileModal({ personId, onClose, all }: PersonPro
   const history = all(historySql, [personId]);
 
   return (
-    <Presence>
-      <Motion animations={animations.fade} defaultAnimationState="enter">
-        <Dialog open onOpenChange={(_, d) => { if (!d.open) onClose(); }}>
+    <Motion animations={animations.fade} defaultAnimationState="enter">
+      <Dialog open onOpenChange={(_, d) => { if (!d.open) onClose(); }}>
           <DialogSurface>
             <DialogTitle action={
               <Tooltip content="Close" relationship="label">
@@ -126,7 +125,6 @@ export default function PersonProfileModal({ personId, onClose, all }: PersonPro
         </DialogActions>
           </DialogSurface>
         </Dialog>
-      </Motion>
-    </Presence>
+    </Motion>
   );
 }

--- a/src/components/PersonProfileModal.tsx
+++ b/src/components/PersonProfileModal.tsx
@@ -6,9 +6,12 @@ import {
   DialogBody,
   DialogActions,
   Button,
+  Tooltip,
   makeStyles,
   tokens,
 } from "@fluentui/react-components";
+import { Presence, Motion, animations } from "@fluentui/react-motion";
+import { Dismiss24Regular } from "@fluentui/react-icons";
 
 interface PersonProfileModalProps {
   personId: number;
@@ -65,9 +68,23 @@ export default function PersonProfileModal({ personId, onClose, all }: PersonPro
   const history = all(historySql, [personId]);
 
   return (
-    <Dialog open onOpenChange={(_, d) => { if (!d.open) onClose(); }}>
-      <DialogSurface aria-describedby={undefined}>
-        <DialogTitle>{person.first_name} {person.last_name}</DialogTitle>
+    <Presence>
+      <Motion animations={animations.fade} defaultAnimationState="enter">
+        <Dialog open onOpenChange={(_, d) => { if (!d.open) onClose(); }}>
+          <DialogSurface>
+            <DialogTitle action={
+              <Tooltip content="Close" relationship="label">
+                <Button
+                  appearance="subtle"
+                  aria-label="Close dialog"
+                  icon={<Dismiss24Regular />}
+                  onClick={onClose}
+                  style={{ color: tokens.colorNeutralForeground1 }}
+                />
+              </Tooltip>
+            }>
+              {person.first_name} {person.last_name}
+            </DialogTitle>
         <DialogBody>
           <div className={s.sectionTitle}>Info</div>
           <div className={s.grid}>
@@ -107,7 +124,9 @@ export default function PersonProfileModal({ personId, onClose, all }: PersonPro
         <DialogActions>
           <Button appearance="primary" onClick={onClose}>Close</Button>
         </DialogActions>
-      </DialogSurface>
-    </Dialog>
+          </DialogSurface>
+        </Dialog>
+      </Motion>
+    </Presence>
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,7 @@ import react from "@vitejs/plugin-react";
 export default defineConfig({
   plugins: [react()],
   optimizeDeps: {
-    include: ["@fluentui/react-components", "@fluentui/react-icons"],
+    include: ["@fluentui/react-components", "@fluentui/react-icons", "@fluentui/react-motion"],
     exclude: ["sql.js"], // sql.js ships ESM/wasm; avoid prebundling issues
   },
   assetsInclude: ["**/*.wasm"],


### PR DESCRIPTION
## Summary
- add tooltip-driven icon-only close button for PersonProfileModal
- wrap profile dialog in Fluent presence motion for subtle animation
- include `@fluentui/react-motion` and Vite optimization for motion components

## Testing
- `npm run build` *(fails: Cannot find package '@vitejs/plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_689ffa47d2d8832282c8bb524be74212