### PR TITLE
Use app icon instead of text in top toolbar

### DIFF
--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -76,7 +76,7 @@ export default function Toolbar({
   return (
     <div className={s.root}>
       <div className={s.left}>
-        <Text weight="semibold">Scheduler</Text>
+        <img src="/favicon-32x32.png" alt="Scheduler" width={32} height={32} />
         {!sqlDb && <Tooltip content="No database loaded" relationship="label"><Spinner size="tiny" /></Tooltip>}
   <FluentToolbar aria-label="File actions" className={s.actionsBar} size="small">
           <Tooltip content="New DB" relationship="label">

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -37,7 +37,7 @@ export default function TopBar({ appName = 'Scheduler', ready, sqlDb, canSave, c
   return (
     <header className={s.root}>
       <div className={s.left}>
-        <Text weight="semibold">{appName}</Text>
+        <img src="/favicon-32x32.png" alt={appName} width={32} height={32} />
         {!sqlDb && <Tooltip content="No database loaded" relationship="label"><Spinner size="tiny" /></Tooltip>}
         <FluentToolbar aria-label="File actions" className={s.actionsBar} size="small">
           <Tooltip content="New DB" relationship="label">


### PR DESCRIPTION
## Summary
- replace toolbar title text with app icon
- swap TopBar and Toolbar components to display favicon instead of "Scheduler"

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a23af914bc8322a9ffdcc2b593e83a