### PR TITLE
Fix sidebar to remain static while scrolling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1313,6 +1313,8 @@ function PeopleEditor(){
       width: '100%',
       maxWidth: '100%',
       overflow: 'hidden',
+      boxSizing: 'border-box',
+      paddingLeft: '80px',
       backgroundColor: (themeName === "dark" ? webDarkTheme : webLightTheme).colorNeutralBackground1,
     },
     contentRow: {

--- a/src/components/SideRail.tsx
+++ b/src/components/SideRail.tsx
@@ -28,11 +28,12 @@ export interface SideRailProps {
 
 const useStyles = makeStyles({
   root: {
-  width: "80px",
-  minWidth: 0,
-  height: "100vh",
-  position: "sticky",
-  top: 0,
+    width: "80px",
+    minWidth: 0,
+    height: "100vh",
+    position: "fixed",
+    top: 0,
+    left: 0,
     padding: tokens.spacingVerticalS,
     display: "flex",
     flexDirection: "column",


### PR DESCRIPTION
## Summary
- Convert sidebar to a fixed element so it no longer scrolls with the page
- Add left padding to app shell so content scrolls next to the fixed sidebar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa4867d1e883228d64609e63629960