### PR TITLE
Add monthly shift notes with tooltip

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -148,6 +148,7 @@ export default function App() {
   const [monthlyDefaults, setMonthlyDefaults] = useState<any[]>([]);
   const [monthlyEditing, setMonthlyEditing] = useState(false);
   const [monthlyOverrides, setMonthlyOverrides] = useState<any[]>([]);
+  const [monthlyNotes, setMonthlyNotes] = useState<any[]>([]);
 
   // UI: simple dialogs
   const [showNeedsEditor, setShowNeedsEditor] = useState(false);
@@ -535,6 +536,8 @@ export default function App() {
     setMonthlyDefaults(rows);
     const ov = all(`SELECT * FROM monthly_default_day WHERE month=?`, [month]);
     setMonthlyOverrides(ov);
+    const notes = all(`SELECT * FROM monthly_note WHERE month=?`, [month]);
+    setMonthlyNotes(notes);
   // Reflect changes to training from monthly assignments
   syncTrainingFromMonthly();
   }
@@ -567,6 +570,19 @@ export default function App() {
   syncTrainingFromMonthly();
   }
 
+  function setMonthlyNote(personId: number, note: string) {
+    if (!sqlDb) return;
+    if (note) {
+      run(`INSERT INTO monthly_note (month, person_id, note) VALUES (?,?,?)
+           ON CONFLICT(month, person_id) DO UPDATE SET note=excluded.note`,
+          [selectedMonth, personId, note]);
+    } else {
+      run(`DELETE FROM monthly_note WHERE month=? AND person_id=?`,
+          [selectedMonth, personId]);
+    }
+    loadMonthlyDefaults(selectedMonth);
+  }
+
   function setMonthlyDefaultForMonth(month: string, personId: number, segment: Segment, roleId: number | null) {
     if (!sqlDb) return;
     if (roleId != null) {
@@ -596,6 +612,14 @@ export default function App() {
         `INSERT INTO monthly_default_day (month, person_id, weekday, segment, role_id) VALUES (?,?,?,?,?)
          ON CONFLICT(month, person_id, weekday, segment) DO UPDATE SET role_id=excluded.role_id`,
         [toMonth, row.person_id, row.weekday, row.segment, row.role_id]
+      );
+    }
+    const nrows = all(`SELECT person_id, note FROM monthly_note WHERE month=?`, [fromMonth]);
+    for (const row of nrows) {
+      run(
+        `INSERT INTO monthly_note (month, person_id, note) VALUES (?,?,?)
+         ON CONFLICT(month, person_id) DO UPDATE SET note=excluded.note`,
+        [toMonth, row.person_id, row.note]
       );
     }
     loadMonthlyDefaults(toMonth);
@@ -1439,10 +1463,12 @@ function PeopleEditor(){
               segments={segments}
               monthlyDefaults={monthlyDefaults}
               monthlyOverrides={monthlyOverrides}
+              monthlyNotes={monthlyNotes}
               monthlyEditing={monthlyEditing}
               setMonthlyEditing={setMonthlyEditing}
               setMonthlyDefault={setMonthlyDefault}
               setWeeklyOverride={setWeeklyOverride}
+              setMonthlyNote={setMonthlyNote}
               copyMonthlyDefaults={copyMonthlyDefaults}
               applyMonthlyDefaults={applyMonthlyDefaults}
               exportMonthlyDefaults={exportMonthlyDefaults}

--- a/src/components/MonthlyDefaults.tsx
+++ b/src/components/MonthlyDefaults.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from "react";
-import { Input, Button, Checkbox, Table, TableHeader, TableHeaderCell, TableBody, TableRow, TableCell, Dialog, DialogSurface, DialogBody, DialogTitle, DialogContent, DialogActions, Link, makeStyles, tokens, Toolbar, ToolbarButton, ToolbarDivider, Dropdown, Option } from "@fluentui/react-components";
+import { Input, Button, Checkbox, Table, TableHeader, TableHeaderCell, TableBody, TableRow, TableCell, Dialog, DialogSurface, DialogBody, DialogTitle, DialogContent, DialogActions, Link, makeStyles, tokens, Toolbar, ToolbarButton, ToolbarDivider, Dropdown, Option, Tooltip, Textarea } from "@fluentui/react-components";
+import { Note20Regular } from "@fluentui/react-icons";
 import SmartSelect from "./controls/SmartSelect";
 import PersonName from "./PersonName";
 import { exportMonthOneSheetXlsx } from "../excel/export-one-sheet";
@@ -16,10 +17,12 @@ interface MonthlyDefaultsProps {
   segments: SegmentRow[];
   monthlyDefaults: any[];
   monthlyOverrides: any[];
+  monthlyNotes: any[];
   monthlyEditing: boolean;
   setMonthlyEditing: (v: boolean) => void;
   setMonthlyDefault: (personId: number, segment: Segment, roleId: number | null) => void;
   setWeeklyOverride: (personId: number, weekday: number, segment: Segment, roleId: number | null) => void;
+  setMonthlyNote: (personId: number, note: string) => void;
   copyMonthlyDefaults: (fromMonth: string, toMonth: string) => void;
   applyMonthlyDefaults: (month: string) => void;
   exportMonthlyDefaults: (month: string) => void;
@@ -35,10 +38,12 @@ export default function MonthlyDefaults({
   segments,
   monthlyDefaults,
   monthlyOverrides,
+  monthlyNotes,
   monthlyEditing,
   setMonthlyEditing,
   setMonthlyDefault,
   setWeeklyOverride,
+  setMonthlyNote,
   copyMonthlyDefaults,
   applyMonthlyDefaults,
   exportMonthlyDefaults,
@@ -89,6 +94,7 @@ export default function MonthlyDefaults({
   const [activeOnly, setActiveOnly] = useState(false);
   const [commuterOnly, setCommuterOnly] = useState(false);
   const [weekdayPerson, setWeekdayPerson] = useState<number | null>(null);
+  const [notePerson, setNotePerson] = useState<number | null>(null);
 
   const viewPeople = useMemo(() => {
     let filtered = people.filter(p => {
@@ -185,6 +191,29 @@ export default function MonthlyDefaults({
     );
   }
 
+  function NoteModal({ personId, onClose }: { personId: number; onClose: () => void }) {
+    const person = people.find(p => p.id === personId);
+    const existing = monthlyNotes.find(n => n.person_id === personId);
+    const [text, setText] = useState(existing?.note ?? "");
+    if (!person) return null;
+    return (
+      <Dialog open onOpenChange={(_, d)=>{ if(!d.open) onClose(); }}>
+        <DialogSurface>
+          <DialogBody>
+            <DialogTitle>Notes - {person.first_name} {person.last_name}</DialogTitle>
+            <DialogContent>
+              <Textarea value={text} onChange={(_, data)=>setText(data.value)} />
+            </DialogContent>
+            <DialogActions>
+              <Button appearance="primary" onClick={()=>{ setMonthlyNote(personId, text); onClose(); }}>Save</Button>
+              <Button onClick={onClose}>Cancel</Button>
+            </DialogActions>
+          </DialogBody>
+        </DialogSurface>
+      </Dialog>
+    );
+  }
+
   return (
     <div className={styles.root}>
       <div className={styles.toolbar}>
@@ -235,14 +264,19 @@ export default function MonthlyDefaults({
             {viewPeople.map((p: any) => (
               <TableRow key={p.id}>
                 <TableCell>
-                  <PersonName personId={p.id}>
-                    {p.last_name}, {p.first_name}
-                  </PersonName>
-                  {monthlyEditing && (
-                    <Link appearance="subtle" className={styles.inlineLink} onClick={() => setWeekdayPerson(p.id)}>
-                      Days{monthlyOverrides.some((o) => o.person_id === p.id) ? "*" : ""}
-                    </Link>
-                  )}
+                  <div style={{ display: 'flex', alignItems: 'center', columnGap: tokens.spacingHorizontalS }}>
+                    <PersonName personId={p.id}>
+                      {p.last_name}, {p.first_name}
+                    </PersonName>
+                    <Tooltip content={monthlyNotes.find(n => n.person_id === p.id)?.note ?? 'Add note'}>
+                      <Button size="small" appearance="subtle" icon={<Note20Regular />} onClick={() => setNotePerson(p.id)} />
+                    </Tooltip>
+                    {monthlyEditing && (
+                      <Link appearance="subtle" className={styles.inlineLink} onClick={() => setWeekdayPerson(p.id)}>
+                        Days{monthlyOverrides.some((o) => o.person_id === p.id) ? "*" : ""}
+                      </Link>
+                    )}
+                  </div>
                 </TableCell>
                 {segmentNames.map((seg) => {
                   const def = monthlyDefaults.find(
@@ -272,6 +306,9 @@ export default function MonthlyDefaults({
       </div>
       {weekdayPerson !== null && (
         <WeeklyOverrideModal personId={weekdayPerson} onClose={() => setWeekdayPerson(null)} />
+      )}
+      {notePerson !== null && (
+        <NoteModal personId={notePerson} onClose={() => setNotePerson(null)} />
       )}
     </div>
   );

--- a/src/services/migrations.ts
+++ b/src/services/migrations.ts
@@ -60,6 +60,17 @@ export const migrate11AddTrainingSource: Migration = (db) => {
   }
 };
 
+export const migrate12AddMonthlyNotes: Migration = (db) => {
+  db.run(`CREATE TABLE IF NOT EXISTS monthly_note (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      month TEXT NOT NULL,
+      person_id INTEGER NOT NULL,
+      note TEXT,
+      UNIQUE(month, person_id),
+      FOREIGN KEY (person_id) REFERENCES person(id)
+    );`);
+};
+
 export const migrate6AddExportGroup: Migration = (db) => {
   db.run(`CREATE TABLE IF NOT EXISTS export_group (
       group_id INTEGER PRIMARY KEY,
@@ -513,6 +524,15 @@ const migrations: Record<number, Migration> = {
       source TEXT DEFAULT 'TeamsImport',
       FOREIGN KEY (person_id) REFERENCES person(id)
     );`);
+
+    db.run(`CREATE TABLE IF NOT EXISTS monthly_note (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      month TEXT NOT NULL,
+      person_id INTEGER NOT NULL,
+      note TEXT,
+      UNIQUE(month, person_id),
+      FOREIGN KEY (person_id) REFERENCES person(id)
+    );`);
   },
   2: (db) => {
     // Ensure training table has 'source' column
@@ -558,6 +578,7 @@ const migrations: Record<number, Migration> = {
   9: migrate8FixSegmentConstraints, // Run the same migration again as 9 to fix failed migration 8
   10: migrate10BackfillGroupCustomColor,
   11: migrate11AddTrainingSource,
+  12: migrate12AddMonthlyNotes,
 };
 
 export function addMigration(version: number, fn: Migration) {


### PR DESCRIPTION
## Summary
- add `monthly_note` table and migration
- support monthly notes in state and copying
- add notes button with tooltip and editor on Monthly Defaults page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68ac6bfe02388322a96497c8146967b8