### PR TITLE
fix: constrain combobox width in monthly defaults

### DIFF
--- a/src/components/controls/SmartSelect.tsx
+++ b/src/components/controls/SmartSelect.tsx
@@ -56,7 +56,14 @@ export default function SmartSelect({
       placeholder={placeholder}
       disabled={disabled}
       className={className}
-      style={style}
+      // Ensure the combobox never overflows its container so controls
+      // in tight grids or tables don't overlap each other.
+      style={{
+        width: "100%",
+        maxWidth: "100%",
+        boxSizing: "border-box",
+        ...style,
+      }}
     >
       {options.map((o) => (
         <Option key={o.value} value={o.value} disabled={o.disabled} text={o.label}>


### PR DESCRIPTION
## Summary
- prevent SmartSelect comboboxes from overflowing their container

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ac7122b6b08322bb29b6797f5bd031