### PR TITLE
feat: add lunch jobs sheet to monthly defaults export

### DIFF
--- a/src/excel/export-one-sheet.ts
+++ b/src/excel/export-one-sheet.ts
@@ -72,6 +72,10 @@ type Buckets = Record<'regular'|'commuter',
   Record<string, Record<string, { AM: Set<DayLetter>; PM: Set<DayLetter>; roles: Set<string> }>>
 >;
 
+type LunchBuckets = Record<'regular'|'commuter',
+  Record<string, Record<string, { days: Set<DayLetter>; roles: Set<string> }>>
+>;
+
 // ---------- DB helpers ----------
 function requireDb() {
   const db = (globalThis as any).sqlDb;
@@ -160,6 +164,11 @@ function isAllowedByAvail(day: DayLetter, seg: Seg, row: WithAvail): boolean {
   if (!ac) return false;
   if (ac === 'B') return true;
   return ac === seg;
+}
+
+function isAllowedForLunch(day: DayLetter, row: WithAvail): boolean {
+  const ac = availCodeFor(day, row);
+  return ac === 'AM' || ac === 'PM' || ac === 'B';
 }
 
 export async function exportMonthOneSheetXlsx(month: string): Promise<void> {
@@ -424,6 +433,190 @@ export async function exportMonthOneSheetXlsx(month: string): Promise<void> {
     paneState.dining = afterRegular + 1;
 
     renderSection('commuter');
+  }
+
+  // ---------- Lunch jobs sheet ----------
+  const lunchDefaults = all<DefaultRow>(
+    `SELECT md.person_id, md.segment,
+            g.name AS group_name, r.id AS role_id, r.name AS role_name,
+            (p.last_name || ', ' || p.first_name) AS person,
+            p.commuter AS commuter,
+            p.avail_mon, p.avail_tue, p.avail_wed, p.avail_thu, p.avail_fri,
+            md.month as month
+       FROM monthly_default md
+      JOIN role r ON r.id = md.role_id
+      JOIN grp  g ON g.id = r.group_id
+      JOIN person p ON p.id = md.person_id
+      WHERE ${mdMonth.where} AND p.active = 1 AND UPPER(md.segment) = 'LUNCH'
+      ORDER BY g.name, person`,
+    mdMonth.params
+  );
+
+  const lunchPerDays = all<DayRow>(
+    `SELECT mdd.person_id, mdd.weekday, mdd.segment,
+            g.name AS group_name, r.id AS role_id, r.name AS role_name,
+            (p.last_name || ', ' || p.first_name) AS person,
+            p.commuter AS commuter,
+            p.avail_mon, p.avail_tue, p.avail_wed, p.avail_thu, p.avail_fri,
+            mdd.month as month
+       FROM monthly_default_day mdd
+      JOIN role r ON r.id = mdd.role_id
+      JOIN grp  g ON g.id = r.group_id
+      JOIN person p ON p.id = mdd.person_id
+      WHERE ${mddMonth.where} AND p.active = 1 AND UPPER(mdd.segment) = 'LUNCH'`,
+    mddMonth.params
+  );
+
+  const lunchBuckets: LunchBuckets = { regular: {}, commuter: {} };
+  const lunchPerDayMap = new Map<number, Map<DayLetter, number>>();
+
+  for (const row of lunchPerDays) {
+    const dayLetter = weekdayToLetter(row.weekday);
+    if (!dayLetter) continue;
+    if (!isAllowedForLunch(dayLetter, row)) continue;
+    const code = GROUP_INFO[row.group_name]?.code;
+    if (!code) continue;
+    const kind: 'regular' | 'commuter' = row.commuter ? 'commuter' : 'regular';
+    const groupBucket = lunchBuckets[kind][code] || (lunchBuckets[kind][code] = {});
+    const personBucket = groupBucket[row.person] || (groupBucket[row.person] = { days: new Set<DayLetter>(), roles: new Set<string>() });
+    personBucket.roles.add(row.role_name);
+    personBucket.days.add(dayLetter);
+    let dayMap = lunchPerDayMap.get(row.person_id);
+    if (!dayMap) {
+      dayMap = new Map<DayLetter, number>();
+      lunchPerDayMap.set(row.person_id, dayMap);
+    }
+    dayMap.set(dayLetter, row.role_id);
+  }
+
+  for (const row of lunchDefaults) {
+    const code = GROUP_INFO[row.group_name]?.code;
+    if (!code) continue;
+    const dayMap = lunchPerDayMap.get(row.person_id);
+    const keepLetters: DayLetter[] = [];
+    for (const d of DAY_ORDER) {
+      if (!isAllowedForLunch(d, row)) continue;
+      const overriddenRoleId = dayMap?.get(d);
+      if (overriddenRoleId == null || overriddenRoleId === row.role_id) {
+        keepLetters.push(d);
+      }
+    }
+    if (keepLetters.length === 0) continue;
+    const kind: 'regular' | 'commuter' = row.commuter ? 'commuter' : 'regular';
+    const groupBucket = lunchBuckets[kind][code] || (lunchBuckets[kind][code] = {});
+    const personBucket = groupBucket[row.person] || (groupBucket[row.person] = { days: new Set<DayLetter>(), roles: new Set<string>() });
+    personBucket.roles.add(row.role_name);
+    for (const d of keepLetters) personBucket.days.add(d);
+  }
+
+  const wsL = wb.addWorksheet('Lunch Jobs');
+  wsL.columns = [
+    { width:26 }, { width:16 }, { width:5 }, { width:14 }, { width:2 },
+    { width:26 }, { width:16 }, { width:5 }, { width:14 }, { width:2 },
+    { width:26 }, { width:16 }, { width:5 }, { width:14 }
+  ];
+
+  wsL.mergeCells(1,1,1,14);
+  const lunchTitle = wsL.getCell(1,1);
+  lunchTitle.value = `Lunch Jobs — ${titleText}`;
+  lunchTitle.font = { bold: true, size: 18, name: 'Calibri' };
+  lunchTitle.alignment = { horizontal: 'center' };
+
+  const lunchPaneState = { kitchen1: 2, kitchen2: 2, dining: 2 } as Record<'kitchen1'|'kitchen2'|'dining', number>;
+
+  function renderLunchBlock(
+    pane: 'kitchen1'|'kitchen2'|'dining',
+    group: string,
+    people: Record<string,{days:Set<DayLetter>;roles:Set<string>}>)
+  {
+    const startCol = pane==='kitchen1'?1:pane==='kitchen2'?6:11;
+    if (!people || !Object.keys(people).length) return;
+    const rowIndex = lunchPaneState[pane];
+
+    wsL.mergeCells(rowIndex,startCol,rowIndex,startCol+3);
+    const hcell = wsL.getCell(rowIndex,startCol);
+    hcell.value = group;
+    hcell.alignment = { horizontal:'left' };
+    const fill = GROUP_INFO[group]?.color || 'FFEFEFEF';
+    hcell.fill = { type:'pattern', pattern:'solid', fgColor:{argb:fill} };
+    for (let c=startCol;c<=startCol+3;c++) {
+      wsL.getCell(rowIndex,c).font = { bold:true, size:18 };
+    }
+    setRowBorders(wsL.getRow(rowIndex), startCol, startCol+3);
+
+    function simplifyRole(role: string): string | null {
+      if (role === group) return null;
+      const prefix = group + ' ';
+      if (role.startsWith(prefix)) {
+        return role.slice(prefix.length);
+      }
+      return role;
+    }
+
+    let r = rowIndex + 1;
+    const names = Object.keys(people).sort((a,b)=>a.localeCompare(b));
+    for (const name of names) {
+      const info = people[name];
+      wsL.getCell(r,startCol).value = name;
+      const roleNames = Array.from(info.roles)
+        .map(simplifyRole)
+        .filter((v):v is string => Boolean(v));
+      const roleText = Array.from(new Set(roleNames)).sort().join('/');
+      wsL.getCell(r,startCol + 1).value = roleText;
+      wsL.getCell(r,startCol + 2).value = 'Lunch';
+      const dayList = DAY_ORDER.filter(d=>info.days.has(d));
+      const days = dayList.length === DAY_ORDER.length ? 'Full-Time' : dayList.join('/');
+      wsL.getCell(r,startCol + 3).value = days;
+      for (let c=startCol;c<=startCol+3;c++) {
+        wsL.getCell(r,c).font = { size:16 };
+      }
+      setRowBorders(wsL.getRow(r), startCol, startCol+3);
+      r++;
+    }
+    lunchPaneState[pane] = r;
+  }
+
+  function renderLunchSection(kind: 'regular'|'commuter') {
+    for (const g of KITCHEN_COL1_GROUPS) {
+      const code = GROUP_INFO[g]?.code;
+      if (!code) continue;
+      const people = lunchBuckets[kind][code];
+      if (people && Object.keys(people).length) renderLunchBlock('kitchen1', g, people);
+    }
+    for (const g of KITCHEN_COL2_GROUPS) {
+      const code = GROUP_INFO[g]?.code;
+      if (!code) continue;
+      const people = lunchBuckets[kind][code];
+      if (people && Object.keys(people).length) renderLunchBlock('kitchen2', g, people);
+    }
+    for (const g of DINING_GROUPS) {
+      const code = GROUP_INFO[g]?.code;
+      if (!code) continue;
+      const people = lunchBuckets[kind][code];
+      if (people && Object.keys(people).length) renderLunchBlock('dining', g, people);
+    }
+  }
+
+  renderLunchSection('regular');
+
+  const lunchHasAny = (kind:'regular'|'commuter') =>
+    Object.values(lunchBuckets[kind]).some(groupMap => groupMap && Object.keys(groupMap).length);
+
+  if (lunchHasAny('commuter')) {
+    const afterRegular = Math.max(lunchPaneState.kitchen1, lunchPaneState.kitchen2, lunchPaneState.dining);
+    wsL.mergeCells(afterRegular,1,afterRegular,14);
+    const commCell = wsL.getCell(afterRegular,1);
+    commCell.value = 'COMMUTERS';
+    commCell.font = { bold:true, size:18 };
+    commCell.alignment = { horizontal:'left' };
+    commCell.fill = { type:'pattern', pattern:'solid', fgColor:{argb:'FFEFEFEF'} };
+    commCell.border = { top:{ style:'thick' } };
+
+    lunchPaneState.kitchen1 = afterRegular + 1;
+    lunchPaneState.kitchen2 = afterRegular + 1;
+    lunchPaneState.dining = afterRegular + 1;
+
+    renderLunchSection('commuter');
   }
 
   const buffer = await wb.xlsx.writeBuffer();

--- a/src/excel/export-one-sheet.ts
+++ b/src/excel/export-one-sheet.ts
@@ -26,6 +26,11 @@ function loadExportGroups(): { info: GroupInfo; col1: string[]; col2: string[]; 
     else if (r.column_group === 'kitchen2') col2.push(r.group_name);
     else if (r.column_group === 'dining') dining.push(r.group_name);
   }
+  // Ensure Lunch group is available even if export_group lacks an entry
+  if (!info['Lunch']) {
+    info['Lunch'] = { code: 'LUNCH', color: 'FFF9A8D4', column_group: 'dining' };
+    dining.push('Lunch');
+  }
   return { info, col1, col2, dining };
 }
 
@@ -447,7 +452,7 @@ export async function exportMonthOneSheetXlsx(month: string): Promise<void> {
       JOIN role r ON r.id = md.role_id
       JOIN grp  g ON g.id = r.group_id
       JOIN person p ON p.id = md.person_id
-      WHERE ${mdMonth.where} AND p.active = 1 AND UPPER(md.segment) = 'LUNCH'
+      WHERE ${mdMonth.where} AND p.active = 1 AND TRIM(UPPER(md.segment)) = 'LUNCH'
       ORDER BY g.name, person`,
     mdMonth.params
   );
@@ -463,7 +468,7 @@ export async function exportMonthOneSheetXlsx(month: string): Promise<void> {
       JOIN role r ON r.id = mdd.role_id
       JOIN grp  g ON g.id = r.group_id
       JOIN person p ON p.id = mdd.person_id
-      WHERE ${mddMonth.where} AND p.active = 1 AND UPPER(mdd.segment) = 'LUNCH'`,
+      WHERE ${mddMonth.where} AND p.active = 1 AND TRIM(UPPER(mdd.segment)) = 'LUNCH'`,
     mddMonth.params
   );
 


### PR DESCRIPTION
## Summary
- add utility to validate lunch assignments
- include Lunch Jobs worksheet in monthly defaults XLSX export

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adfda3b33c83228ef0e0dbf45d2c74