### PR TITLE
Add availability override support

### DIFF
--- a/src/services/availabilityOverrides.ts
+++ b/src/services/availabilityOverrides.ts
@@ -1,0 +1,25 @@
+import type { Database } from 'sql.js';
+
+export type Availability = 'U' | 'AM' | 'PM' | 'B';
+
+export function getOverride(db: Database, personId: number, date: string): Availability | null {
+  const res = db.exec(
+    `SELECT avail FROM availability_override WHERE person_id=? AND date=?`,
+    [personId, date]
+  );
+  const val = res[0]?.values?.[0]?.[0];
+  return val != null ? (String(val) as Availability) : null;
+}
+
+export function setOverride(db: Database, personId: number, date: string, avail: Availability): void {
+  db.run(
+    `INSERT INTO availability_override (person_id, date, avail) VALUES (?,?,?)
+     ON CONFLICT(person_id, date) DO UPDATE SET avail=excluded.avail`,
+    [personId, date, avail]
+  );
+}
+
+export function deleteOverride(db: Database, personId: number, date: string): void {
+  db.run(`DELETE FROM availability_override WHERE person_id=? AND date=?`, [personId, date]);
+}
+

--- a/src/services/migrations.ts
+++ b/src/services/migrations.ts
@@ -72,6 +72,17 @@ export const migrate12AddMonthlyNotes: Migration = (db) => {
     );`);
 };
 
+export const migrate13AddAvailabilityOverride: Migration = (db) => {
+  db.run(`CREATE TABLE IF NOT EXISTS availability_override (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      person_id INTEGER NOT NULL,
+      date TEXT NOT NULL,
+      avail TEXT CHECK(avail IN ('U','AM','PM','B')) NOT NULL,
+      UNIQUE(person_id, date),
+      FOREIGN KEY (person_id) REFERENCES person(id)
+    );`);
+};
+
 export const migrate6AddExportGroup: Migration = (db) => {
   db.run(`CREATE TABLE IF NOT EXISTS export_group (
       group_id INTEGER PRIMARY KEY,
@@ -571,6 +582,7 @@ const migrations: Record<number, Migration> = {
   10: migrate10BackfillGroupCustomColor,
   11: migrate11AddTrainingSource,
   12: migrate12AddMonthlyNotes,
+  13: migrate13AddAvailabilityOverride,
 };
 
 export function addMigration(version: number, fn: Migration) {


### PR DESCRIPTION
## Summary
- create `availability_override` table and migration
- support reading/writing availability overrides
- factor availability helper and use for monthly defaults and segment options

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b040b33fd4832292fa0faef493f538