### PR TITLE
fix: persist manual training selections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -429,8 +429,13 @@ export default function App() {
     // Only adjust manual-sourced entries; preserve monthly-derived training which reflects history
     run(`DELETE FROM training WHERE person_id=? AND source='manual'`, [personId]);
     for (const rid of rolesSet) {
-      run(`INSERT INTO training (person_id, role_id, status, source) VALUES (?,?, 'Qualified', 'manual')`, [personId, rid]);
+      run(
+        `INSERT INTO training (person_id, role_id, status, source) VALUES (?,?, 'Qualified', 'manual')
+         ON CONFLICT(person_id, role_id) DO UPDATE SET status='Qualified', source='manual'`,
+        [personId, rid]
+      );
     }
+    refreshCaches();
   }
 
   // Assignments


### PR DESCRIPTION
## Summary
- ensure training selections save by upserting records
- refresh caches after manual training changes

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b0e4e331d083228ce36847e142b958