### PR TITLE
Add skill competency tracker module

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { applyMigrations } from "./services/migrations";
 import { listSegments, type Segment, type SegmentRow } from "./services/segments";
 import { listSegmentAdjustments, type SegmentAdjustmentRow } from "./services/segmentAdjustments";
 import { availabilityFor } from "./services/availability";
-import SideRail from "./components/SideRail";
+import SideRail, { TabKey } from "./components/SideRail";
 import TopBar from "./components/TopBar";
 const DailyRunBoard = React.lazy(() => import("./components/DailyRunBoard"));
 const AdminView = React.lazy(() => import("./components/AdminView"));
@@ -16,6 +16,7 @@ import { Button, Checkbox, Dropdown, Input, Option, Table, TableHeader, TableHea
 import { FluentProvider, webDarkTheme, webLightTheme } from "@fluentui/react-components";
 import MonthlyDefaults from "./components/MonthlyDefaults";
 import CrewHistoryView from "./components/CrewHistoryView";
+import SkillTracker from "./components/SkillTracker";
 
 /*
 MVP: Pure-browser scheduler for Microsoft Teams Shifts
@@ -129,7 +130,7 @@ export default function App() {
   const [selectedDate, setSelectedDate] = useState<string>(() => fmtDateMDY(new Date()));
   const [exportStart, setExportStart] = useState<string>(() => ymd(new Date()));
   const [exportEnd, setExportEnd] = useState<string>(() => ymd(new Date()));
-  const [activeTab, setActiveTab] = useState<"RUN" | "PEOPLE" | "NEEDS" | "EXPORT" | "MONTHLY" | "HISTORY" | "ADMIN">("RUN");
+  const [activeTab, setActiveTab] = useState<TabKey>("RUN");
   const [activeRunSegment, setActiveRunSegment] = useState<Segment>("AM");
 
   // People cache for quick UI (id -> record)
@@ -1597,6 +1598,9 @@ function PeopleEditor(){
               </Suspense>
             )}
           {activeTab === 'PEOPLE' && <PeopleEditor />}
+          {activeTab === 'SKILLS' && (
+            <SkillTracker people={people} roles={roles} all={all} run={run} />
+          )}
           {activeTab === 'NEEDS' && <BaselineView />}
           {activeTab === 'EXPORT' && (
             <Suspense fallback={<div className="p-4 text-slate-600">Loading Export Preview…</div>}>

--- a/src/components/SideRail.tsx
+++ b/src/components/SideRail.tsx
@@ -15,7 +15,15 @@ import {
 } from "@fluentui/react-icons";
 import "../styles/tooltip.css";
 
-export type TabKey = "RUN" | "PEOPLE" | "NEEDS" | "EXPORT" | "MONTHLY" | "HISTORY" | "ADMIN";
+export type TabKey =
+  | "RUN"
+  | "PEOPLE"
+  | "SKILLS"
+  | "NEEDS"
+  | "EXPORT"
+  | "MONTHLY"
+  | "HISTORY"
+  | "ADMIN";
 
 export interface SideRailProps {
   ready: boolean;
@@ -108,6 +116,7 @@ export default function SideRail({
   const baseNav: NavItem[] = [
     { type: "page", key: "RUN", label: "Run", icon: <CalendarDay20Regular /> },
     { type: "page", key: "PEOPLE", label: "People", icon: <PeopleCommunity20Regular /> },
+    { type: "page", key: "SKILLS", label: "Skills", icon: <TableSimple20Regular /> },
     { type: "page", key: "NEEDS", label: "Needs", icon: <DocumentTable20Regular /> },
     { type: "page", key: "EXPORT", label: "Export", icon: <Share20Regular /> },
     { type: "page", key: "MONTHLY", label: "Monthly", icon: <CalendarLtr20Regular /> },

--- a/src/components/SkillTracker.tsx
+++ b/src/components/SkillTracker.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Table, TableHeader, TableRow, TableHeaderCell, TableBody, TableCell, Dropdown, Option, makeStyles, tokens } from "@fluentui/react-components";
+import { Dropdown, Option, makeStyles, tokens } from "@fluentui/react-components";
 
 interface SkillTrackerProps {
   people: any[];
@@ -63,7 +63,16 @@ export default function SkillTracker({ people, roles, all, run }: SkillTrackerPr
       borderRadius: tokens.borderRadiusLarge,
       overflow: "auto",
       maxHeight: "60vh",
+      width: "100%",
+      boxShadow: tokens.shadow2,
     },
+    table: { width: "100%", borderCollapse: "collapse" },
+    headerCell: {
+      padding: tokens.spacingHorizontalS,
+      textAlign: "left",
+      backgroundColor: tokens.colorNeutralBackground2,
+    },
+    cell: { padding: tokens.spacingHorizontalS, textAlign: "center" },
     cellDropdown: { width: "60px" },
   });
   const s = useStyles();
@@ -72,25 +81,27 @@ export default function SkillTracker({ people, roles, all, run }: SkillTrackerPr
     <div className={s.root}>
       <div className={s.title}>Skill Competency Tracker</div>
       <div className={s.tableWrap}>
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHeaderCell>Person</TableHeaderCell>
+        <table className={s.table}>
+          <thead>
+            <tr>
+              <th className={s.headerCell}>Person</th>
               {roles.map((r: any) => (
-                <TableHeaderCell key={r.id}>{r.name}</TableHeaderCell>
+                <th key={r.id} className={s.headerCell}>
+                  {r.name}
+                </th>
               ))}
-            </TableRow>
-          </TableHeader>
-          <TableBody>
+            </tr>
+          </thead>
+          <tbody>
             {people.map((p: any) => (
-              <TableRow key={p.id}>
-                <TableCell>
+              <tr key={p.id}>
+                <td className={s.cell}>
                   {p.last_name}, {p.first_name}
-                </TableCell>
+                </td>
                 {roles.map((r: any) => {
                   const rating = ratings[p.id]?.[r.id];
                   return (
-                    <TableCell key={r.id}>
+                    <td key={r.id} className={s.cell}>
                       <Dropdown
                         className={s.cellDropdown}
                         selectedOptions={rating ? [String(rating)] : []}
@@ -107,13 +118,13 @@ export default function SkillTracker({ people, roles, all, run }: SkillTrackerPr
                         <Option value="4">4</Option>
                         <Option value="5">5</Option>
                       </Dropdown>
-                    </TableCell>
+                    </td>
                   );
                 })}
-              </TableRow>
+              </tr>
             ))}
-          </TableBody>
-        </Table>
+          </tbody>
+        </table>
       </div>
     </div>
   );

--- a/src/components/SkillTracker.tsx
+++ b/src/components/SkillTracker.tsx
@@ -1,0 +1,120 @@
+import React, { useEffect, useState } from "react";
+import { Table, TableHeader, TableRow, TableHeaderCell, TableBody, TableCell, Dropdown, Option, makeStyles, tokens } from "@fluentui/react-components";
+
+interface SkillTrackerProps {
+  people: any[];
+  roles: any[];
+  all: (sql: string, params?: any[]) => any[];
+  run: (sql: string, params?: any[]) => void;
+}
+
+export default function SkillTracker({ people, roles, all, run }: SkillTrackerProps) {
+  const [ratings, setRatings] = useState<Record<number, Record<number, number>>>({});
+
+  useEffect(() => {
+    try {
+      const rows = all(`SELECT person_id, role_id, rating FROM competency`);
+      const map: Record<number, Record<number, number>> = {};
+      for (const r of rows) {
+        if (!map[r.person_id]) map[r.person_id] = {};
+        map[r.person_id][r.role_id] = r.rating;
+      }
+      setRatings(map);
+    } catch {
+      setRatings({});
+    }
+  }, [people, roles, all]);
+
+  function setRating(personId: number, roleId: number, rating: number | null) {
+    if (rating === null) {
+      run(`DELETE FROM competency WHERE person_id=? AND role_id=?`, [personId, roleId]);
+      setRatings(prev => {
+        const next = { ...prev };
+        if (next[personId]) {
+          delete next[personId][roleId];
+        }
+        return { ...next };
+      });
+    } else {
+      run(
+        `INSERT INTO competency (person_id, role_id, rating) VALUES (?,?,?)
+         ON CONFLICT(person_id, role_id) DO UPDATE SET rating=excluded.rating`,
+        [personId, roleId, rating]
+      );
+      setRatings(prev => {
+        const next = { ...prev };
+        if (!next[personId]) next[personId] = {};
+        next[personId][roleId] = rating;
+        return { ...next };
+      });
+    }
+  }
+
+  const useStyles = makeStyles({
+    root: {
+      padding: tokens.spacingHorizontalM,
+      display: "flex",
+      flexDirection: "column",
+      gap: tokens.spacingVerticalS,
+    },
+    title: { fontWeight: tokens.fontWeightSemibold, fontSize: tokens.fontSizeBase400 },
+    tableWrap: {
+      border: `1px solid ${tokens.colorNeutralStroke2}`,
+      borderRadius: tokens.borderRadiusLarge,
+      overflow: "auto",
+      maxHeight: "60vh",
+    },
+    cellDropdown: { width: "60px" },
+  });
+  const s = useStyles();
+
+  return (
+    <div className={s.root}>
+      <div className={s.title}>Skill Competency Tracker</div>
+      <div className={s.tableWrap}>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHeaderCell>Person</TableHeaderCell>
+              {roles.map((r: any) => (
+                <TableHeaderCell key={r.id}>{r.name}</TableHeaderCell>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {people.map((p: any) => (
+              <TableRow key={p.id}>
+                <TableCell>
+                  {p.last_name}, {p.first_name}
+                </TableCell>
+                {roles.map((r: any) => {
+                  const rating = ratings[p.id]?.[r.id];
+                  return (
+                    <TableCell key={r.id}>
+                      <Dropdown
+                        className={s.cellDropdown}
+                        selectedOptions={rating ? [String(rating)] : []}
+                        onOptionSelect={(_, data) => {
+                          const val = parseInt(String(data.optionValue ?? data.optionText));
+                          if (!val) setRating(p.id, r.id, null);
+                          else setRating(p.id, r.id, val);
+                        }}
+                      >
+                        <Option value="">-</Option>
+                        <Option value="1">1</Option>
+                        <Option value="2">2</Option>
+                        <Option value="3">3</Option>
+                        <Option value="4">4</Option>
+                        <Option value="5">5</Option>
+                      </Dropdown>
+                    </TableCell>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/src/services/migrations.ts
+++ b/src/services/migrations.ts
@@ -105,6 +105,17 @@ export const migrate15AddSegmentAdjustmentRole: Migration = (db) => {
   } catch {}
 };
 
+export const migrate16AddCompetency: Migration = (db) => {
+  db.run(`CREATE TABLE IF NOT EXISTS competency (
+      person_id INTEGER NOT NULL,
+      role_id INTEGER NOT NULL,
+      rating INTEGER CHECK(rating BETWEEN 1 AND 5) NOT NULL,
+      PRIMARY KEY (person_id, role_id),
+      FOREIGN KEY (person_id) REFERENCES person(id),
+      FOREIGN KEY (role_id) REFERENCES role(id)
+    );`);
+};
+
 export const migrate6AddExportGroup: Migration = (db) => {
   db.run(`CREATE TABLE IF NOT EXISTS export_group (
       group_id INTEGER PRIMARY KEY,
@@ -607,6 +618,7 @@ const migrations: Record<number, Migration> = {
   13: migrate13AddAvailabilityOverride,
   14: migrate14AddSegmentAdjustment,
   15: migrate15AddSegmentAdjustmentRole,
+  16: migrate16AddCompetency,
 };
 
 export function addMigration(version: number, fn: Migration) {


### PR DESCRIPTION
## Summary
- add Skill Competency Tracker tab with dropdown ratings for each person and role
- store ratings in new `competency` table via migration
- expose new Skills tab in side navigation and main app

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4c484d2b083228e3a0360a30b95f8