### PR TITLE
Add skill competency tracker tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import TopBar from "./components/TopBar";
 const DailyRunBoard = React.lazy(() => import("./components/DailyRunBoard"));
 const AdminView = React.lazy(() => import("./components/AdminView"));
 const ExportPreview = React.lazy(() => import("./components/ExportPreview"));
+const CompetencyTracker = React.lazy(() => import("./components/CompetencyTracker"));
 import { exportMonthOneSheetXlsx } from "./excel/export-one-sheet";
 import PersonName from "./components/PersonName";
 import PersonProfileModal from "./components/PersonProfileModal";
@@ -129,7 +130,7 @@ export default function App() {
   const [selectedDate, setSelectedDate] = useState<string>(() => fmtDateMDY(new Date()));
   const [exportStart, setExportStart] = useState<string>(() => ymd(new Date()));
   const [exportEnd, setExportEnd] = useState<string>(() => ymd(new Date()));
-  const [activeTab, setActiveTab] = useState<"RUN" | "PEOPLE" | "NEEDS" | "EXPORT" | "MONTHLY" | "HISTORY" | "ADMIN">("RUN");
+  const [activeTab, setActiveTab] = useState<"RUN" | "PEOPLE" | "SKILLS" | "NEEDS" | "EXPORT" | "MONTHLY" | "HISTORY" | "ADMIN">("RUN");
   const [activeRunSegment, setActiveRunSegment] = useState<Segment>("AM");
 
   // People cache for quick UI (id -> record)
@@ -1597,6 +1598,11 @@ function PeopleEditor(){
               </Suspense>
             )}
           {activeTab === 'PEOPLE' && <PeopleEditor />}
+          {activeTab === 'SKILLS' && (
+            <Suspense fallback={<div className="p-4 text-slate-600">Loading Skills…</div>}>
+              <CompetencyTracker people={people} roles={roles} all={all} run={run} />
+            </Suspense>
+          )}
           {activeTab === 'NEEDS' && <BaselineView />}
           {activeTab === 'EXPORT' && (
             <Suspense fallback={<div className="p-4 text-slate-600">Loading Export Preview…</div>}>

--- a/src/components/CompetencyTracker.tsx
+++ b/src/components/CompetencyTracker.tsx
@@ -1,0 +1,78 @@
+import React, { useEffect, useState } from "react";
+import { Table, TableHeader, TableRow, TableHeaderCell, TableBody, TableCell, Dropdown, Option } from "@fluentui/react-components";
+
+interface CompetencyTrackerProps {
+  people: any[];
+  roles: any[];
+  all: (sql: string, params?: any[], db?: any) => any[];
+  run: (sql: string, params?: any[], db?: any) => void;
+}
+
+export default function CompetencyTracker({ people, roles, all, run }: CompetencyTrackerProps) {
+  const [ratings, setRatings] = useState<Record<number, Record<number, number>>>({});
+
+  useEffect(() => {
+    try {
+      const rows = all("SELECT person_id, role_id, score FROM competency", []);
+      const map: Record<number, Record<number, number>> = {};
+      for (const r of rows) {
+        if (!map[r.person_id]) map[r.person_id] = {};
+        map[r.person_id][r.role_id] = r.score;
+      }
+      setRatings(map);
+    } catch {}
+  }, [all, people, roles]);
+
+  const setScore = (personId: number, roleId: number, score: number) => {
+    setRatings(prev => {
+      const next = { ...prev };
+      if (!next[personId]) next[personId] = {};
+      next[personId][roleId] = score;
+      return next;
+    });
+    run(
+      "INSERT INTO competency (person_id, role_id, score) VALUES (?,?,?) ON CONFLICT(person_id, role_id) DO UPDATE SET score=excluded.score",
+      [personId, roleId, score]
+    );
+  };
+
+  return (
+    <div className="p-4 overflow-auto">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHeaderCell>Person</TableHeaderCell>
+            {roles.map(r => (
+              <TableHeaderCell key={r.id}>{r.name}</TableHeaderCell>
+            ))}
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {people.map(p => (
+            <TableRow key={p.id}>
+              <TableCell>{p.first_name} {p.last_name}</TableCell>
+              {roles.map(r => (
+                <TableCell key={r.id}>
+                  <Dropdown
+                    aria-label="Competency"
+                    selectedOptions={ratings[p.id]?.[r.id] ? [String(ratings[p.id][r.id])] : []}
+                    placeholder="-"
+                    onOptionSelect={(e, data) => {
+                      const val = parseInt(String(data.optionValue), 10);
+                      if (!isNaN(val)) setScore(p.id, r.id, val);
+                    }}
+                  >
+                    {[1,2,3,4,5].map(v => (
+                      <Option key={v} value={String(v)}>{v}</Option>
+                    ))}
+                  </Dropdown>
+                </TableCell>
+              ))}
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}
+

--- a/src/components/SideRail.tsx
+++ b/src/components/SideRail.tsx
@@ -15,7 +15,7 @@ import {
 } from "@fluentui/react-icons";
 import "../styles/tooltip.css";
 
-export type TabKey = "RUN" | "PEOPLE" | "NEEDS" | "EXPORT" | "MONTHLY" | "HISTORY" | "ADMIN";
+export type TabKey = "RUN" | "PEOPLE" | "SKILLS" | "NEEDS" | "EXPORT" | "MONTHLY" | "HISTORY" | "ADMIN";
 
 export interface SideRailProps {
   ready: boolean;
@@ -108,6 +108,7 @@ export default function SideRail({
   const baseNav: NavItem[] = [
     { type: "page", key: "RUN", label: "Run", icon: <CalendarDay20Regular /> },
     { type: "page", key: "PEOPLE", label: "People", icon: <PeopleCommunity20Regular /> },
+    { type: "page", key: "SKILLS", label: "Skills", icon: <TableSimple20Regular /> },
     { type: "page", key: "NEEDS", label: "Needs", icon: <DocumentTable20Regular /> },
     { type: "page", key: "EXPORT", label: "Export", icon: <Share20Regular /> },
     { type: "page", key: "MONTHLY", label: "Monthly", icon: <CalendarLtr20Regular /> },

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Button, Tab, TabList, Tooltip, Spinner, Text, Switch, Toolbar as FluentToolbar, ToolbarButton, ToolbarDivider, makeStyles, tokens } from "@fluentui/react-components";
 import { Add20Regular, FolderOpen20Regular, Save20Regular, SaveCopy20Regular } from "@fluentui/react-icons";
 
-type TabKey = "RUN" | "PEOPLE" | "NEEDS" | "EXPORT" | "MONTHLY" | "HISTORY" | "ADMIN";
+type TabKey = "RUN" | "PEOPLE" | "SKILLS" | "NEEDS" | "EXPORT" | "MONTHLY" | "HISTORY" | "ADMIN";
 
 interface ToolbarProps {
   ready: boolean;
@@ -102,6 +102,7 @@ export default function Toolbar({
         >
           <Tab value="RUN">Daily Run</Tab>
           <Tab value="PEOPLE">People</Tab>
+          <Tab value="SKILLS">Skills</Tab>
           <Tab value="NEEDS">Baseline Needs</Tab>
           <Tab value="EXPORT">Export Preview</Tab>
           <Tab value="MONTHLY">Monthly Defaults</Tab>

--- a/src/services/migrations.ts
+++ b/src/services/migrations.ts
@@ -105,6 +105,17 @@ export const migrate15AddSegmentAdjustmentRole: Migration = (db) => {
   } catch {}
 };
 
+export const migrate16AddCompetencyTable: Migration = (db) => {
+  db.run(`CREATE TABLE IF NOT EXISTS competency (
+      person_id INTEGER NOT NULL,
+      role_id INTEGER NOT NULL,
+      score INTEGER NOT NULL CHECK(score BETWEEN 1 AND 5),
+      PRIMARY KEY (person_id, role_id),
+      FOREIGN KEY (person_id) REFERENCES person(id),
+      FOREIGN KEY (role_id) REFERENCES role(id)
+    );`);
+};
+
 export const migrate6AddExportGroup: Migration = (db) => {
   db.run(`CREATE TABLE IF NOT EXISTS export_group (
       group_id INTEGER PRIMARY KEY,
@@ -607,6 +618,7 @@ const migrations: Record<number, Migration> = {
   13: migrate13AddAvailabilityOverride,
   14: migrate14AddSegmentAdjustment,
   15: migrate15AddSegmentAdjustmentRole,
+  16: migrate16AddCompetencyTable,
 };
 
 export function addMigration(version: number, fn: Migration) {


### PR DESCRIPTION
## Summary
- add new Skills tab with competency tracker table to rate people 1-5 per role
- create competency table migration and integrate tab into navigation

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4c484d2b083228e3a0360a30b95f8