### PR TITLE
Add competency tracker tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import TopBar from "./components/TopBar";
 const DailyRunBoard = React.lazy(() => import("./components/DailyRunBoard"));
 const AdminView = React.lazy(() => import("./components/AdminView"));
 const ExportPreview = React.lazy(() => import("./components/ExportPreview"));
+const CompetencyTracker = React.lazy(() => import("./components/CompetencyTracker"));
 import { exportMonthOneSheetXlsx } from "./excel/export-one-sheet";
 import PersonName from "./components/PersonName";
 import PersonProfileModal from "./components/PersonProfileModal";
@@ -129,7 +130,16 @@ export default function App() {
   const [selectedDate, setSelectedDate] = useState<string>(() => fmtDateMDY(new Date()));
   const [exportStart, setExportStart] = useState<string>(() => ymd(new Date()));
   const [exportEnd, setExportEnd] = useState<string>(() => ymd(new Date()));
-  const [activeTab, setActiveTab] = useState<"RUN" | "PEOPLE" | "NEEDS" | "EXPORT" | "MONTHLY" | "HISTORY" | "ADMIN">("RUN");
+  const [activeTab, setActiveTab] = useState<
+    | "RUN"
+    | "PEOPLE"
+    | "SKILLS"
+    | "NEEDS"
+    | "EXPORT"
+    | "MONTHLY"
+    | "HISTORY"
+    | "ADMIN"
+  >("RUN");
   const [activeRunSegment, setActiveRunSegment] = useState<Segment>("AM");
 
   // People cache for quick UI (id -> record)
@@ -1597,6 +1607,11 @@ function PeopleEditor(){
               </Suspense>
             )}
           {activeTab === 'PEOPLE' && <PeopleEditor />}
+          {activeTab === 'SKILLS' && (
+            <Suspense fallback={<div className="p-4 text-slate-600">Loading Skills…</div>}>
+              <CompetencyTracker all={all} run={run} people={people} roles={roles} />
+            </Suspense>
+          )}
           {activeTab === 'NEEDS' && <BaselineView />}
           {activeTab === 'EXPORT' && (
             <Suspense fallback={<div className="p-4 text-slate-600">Loading Export Preview…</div>}>

--- a/src/components/CompetencyTracker.tsx
+++ b/src/components/CompetencyTracker.tsx
@@ -1,0 +1,88 @@
+import React, { useEffect, useState } from "react";
+import { Table, TableHeader, TableRow, TableHeaderCell, TableBody, TableCell, Dropdown, Option, makeStyles, tokens } from "@fluentui/react-components";
+import PersonName from "./PersonName";
+
+interface CompetencyTrackerProps {
+  all: (sql: string, params?: any[]) => any[];
+  run: (sql: string, params?: any[]) => void;
+  people: any[];
+  roles: any[];
+}
+
+export default function CompetencyTracker({ all, run, people, roles }: CompetencyTrackerProps) {
+  const [ratings, setRatings] = useState<Map<string, number>>(new Map());
+
+  useEffect(() => {
+    const rows = all(`SELECT person_id, role_id, rating FROM competency`);
+    const map = new Map<string, number>();
+    for (const r of rows) {
+      map.set(`${r.person_id}|${r.role_id}`, r.rating);
+    }
+    setRatings(map);
+  }, [all, people, roles]);
+
+  function setRating(pid: number, rid: number, rating: number) {
+    run(
+      `INSERT INTO competency (person_id, role_id, rating) VALUES (?,?,?) ON CONFLICT(person_id, role_id) DO UPDATE SET rating=excluded.rating`,
+      [pid, rid, rating]
+    );
+    setRatings(new Map(ratings).set(`${pid}|${rid}`, rating));
+  }
+
+  const useStyles = makeStyles({
+    root: { padding: tokens.spacingHorizontalM },
+    tableWrap: {
+      border: `1px solid ${tokens.colorNeutralStroke2}`,
+      borderRadius: tokens.borderRadiusLarge,
+      overflow: "auto",
+      maxHeight: "60vh",
+      width: "100%",
+      boxShadow: tokens.shadow2,
+    },
+  });
+  const s = useStyles();
+
+  return (
+    <div className={s.root}>
+      <div className={s.tableWrap}>
+        <Table aria-label="Competency table">
+          <TableHeader>
+            <TableRow>
+              <TableHeaderCell>Person</TableHeaderCell>
+              {roles.map((r: any) => (
+                <TableHeaderCell key={r.id}>{r.name}</TableHeaderCell>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {people.map((p: any) => (
+              <TableRow key={p.id}>
+                <TableCell><PersonName personId={p.id}>{p.last_name}, {p.first_name}</PersonName></TableCell>
+                {roles.map((r: any) => {
+                  const key = `${p.id}|${r.id}`;
+                  const rating = ratings.get(key);
+                  return (
+                    <TableCell key={r.id}>
+                      <Dropdown
+                        selectedOptions={rating ? [String(rating)] : []}
+                        onOptionSelect={(_, data) => {
+                          const v = Number(data.optionValue ?? data.optionText);
+                          setRating(p.id, r.id, v);
+                        }}
+                      >
+                        {[1,2,3,4,5].map(n => (
+                          <Option key={n} value={String(n)}>{n}</Option>
+                        ))}
+                      </Dropdown>
+                    </TableCell>
+                  );
+                })}
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/SideRail.tsx
+++ b/src/components/SideRail.tsx
@@ -15,7 +15,7 @@ import {
 } from "@fluentui/react-icons";
 import "../styles/tooltip.css";
 
-export type TabKey = "RUN" | "PEOPLE" | "NEEDS" | "EXPORT" | "MONTHLY" | "HISTORY" | "ADMIN";
+export type TabKey = "RUN" | "PEOPLE" | "SKILLS" | "NEEDS" | "EXPORT" | "MONTHLY" | "HISTORY" | "ADMIN";
 
 export interface SideRailProps {
   ready: boolean;
@@ -108,6 +108,7 @@ export default function SideRail({
   const baseNav: NavItem[] = [
     { type: "page", key: "RUN", label: "Run", icon: <CalendarDay20Regular /> },
     { type: "page", key: "PEOPLE", label: "People", icon: <PeopleCommunity20Regular /> },
+    { type: "page", key: "SKILLS", label: "Skills", icon: <TableSimple20Regular /> },
     { type: "page", key: "NEEDS", label: "Needs", icon: <DocumentTable20Regular /> },
     { type: "page", key: "EXPORT", label: "Export", icon: <Share20Regular /> },
     { type: "page", key: "MONTHLY", label: "Monthly", icon: <CalendarLtr20Regular /> },

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { Button, Tab, TabList, Tooltip, Spinner, Text, Switch, Toolbar as FluentToolbar, ToolbarButton, ToolbarDivider, makeStyles, tokens } from "@fluentui/react-components";
 import { Add20Regular, FolderOpen20Regular, Save20Regular, SaveCopy20Regular } from "@fluentui/react-icons";
 
-type TabKey = "RUN" | "PEOPLE" | "NEEDS" | "EXPORT" | "MONTHLY" | "HISTORY" | "ADMIN";
+type TabKey = "RUN" | "PEOPLE" | "SKILLS" | "NEEDS" | "EXPORT" | "MONTHLY" | "HISTORY" | "ADMIN";
 
 interface ToolbarProps {
   ready: boolean;
@@ -102,6 +102,7 @@ export default function Toolbar({
         >
           <Tab value="RUN">Daily Run</Tab>
           <Tab value="PEOPLE">People</Tab>
+          <Tab value="SKILLS">Skills</Tab>
           <Tab value="NEEDS">Baseline Needs</Tab>
           <Tab value="EXPORT">Export Preview</Tab>
           <Tab value="MONTHLY">Monthly Defaults</Tab>

--- a/src/services/migrations.ts
+++ b/src/services/migrations.ts
@@ -105,6 +105,17 @@ export const migrate15AddSegmentAdjustmentRole: Migration = (db) => {
   } catch {}
 };
 
+export const migrate16AddCompetency: Migration = (db) => {
+  db.run(`CREATE TABLE IF NOT EXISTS competency (
+      person_id INTEGER NOT NULL,
+      role_id INTEGER NOT NULL,
+      rating INTEGER CHECK(rating BETWEEN 1 AND 5) NOT NULL,
+      PRIMARY KEY (person_id, role_id),
+      FOREIGN KEY (person_id) REFERENCES person(id),
+      FOREIGN KEY (role_id) REFERENCES role(id)
+    );`);
+};
+
 export const migrate6AddExportGroup: Migration = (db) => {
   db.run(`CREATE TABLE IF NOT EXISTS export_group (
       group_id INTEGER PRIMARY KEY,
@@ -607,6 +618,7 @@ const migrations: Record<number, Migration> = {
   13: migrate13AddAvailabilityOverride,
   14: migrate14AddSegmentAdjustment,
   15: migrate15AddSegmentAdjustmentRole,
+  16: migrate16AddCompetency,
 };
 
 export function addMigration(version: number, fn: Migration) {


### PR DESCRIPTION
## Summary
- add database table and migration for competency ratings
- implement skill competency tracker component to rate people 1-5 per role
- expose new Skills tab in navigation and toolbar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node node_modules/vite/bin/vite.js build`


------
https://chatgpt.com/codex/tasks/task_e_68c4c484d2b083228e3a0360a30b95f8