### PR TITLE
Add database provider abstraction with Graph scaffolding

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -2,3 +2,19 @@ declare module "*.wasm" { const src: string; export default src; }
 
 // Temporary type shim for packages without bundled types
 declare module "react-grid-layout";
+
+interface ImportMetaEnv {
+  readonly VITE_FEATURE_SP_TRAINING?: string;
+  readonly VITE_AZURE_CLIENT_ID?: string;
+  readonly VITE_AZURE_TENANT_ID?: string;
+  readonly VITE_AZURE_AUTHORITY?: string;
+  readonly VITE_AZURE_REDIRECT_URI?: string;
+  readonly VITE_SHAREPOINT_SITE_ID?: string;
+  readonly VITE_SHAREPOINT_SKILLS_LIST_ID?: string;
+  readonly VITE_SHAREPOINT_PERSON_SKILLS_LIST_ID?: string;
+  readonly VITE_SHAREPOINT_PERSON_QUALITIES_LIST_ID?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/providers/DbProvider.ts
+++ b/src/providers/DbProvider.ts
@@ -1,0 +1,43 @@
+export type SqlQueryAll = (sql: string, params?: any[]) => any[];
+export type SqlExecute = (sql: string, params?: any[]) => void;
+
+export interface TrainingSkill {
+  id: number;
+  code: string;
+  name: string;
+  active: number;
+  groupId: number | null;
+}
+
+export interface PersonSkillRating {
+  personId: number;
+  skillId: number;
+  rating: number;
+}
+
+export interface PersonQualitiesRecord {
+  personId: number;
+  values: Record<string, number>;
+}
+
+export interface DbProvider {
+  readonly kind: "sqljs" | "graph-sharepoint";
+
+  getTrainingSkills(): Promise<TrainingSkill[]>;
+
+  getPersonSkillRatings(): Promise<PersonSkillRating[]>;
+
+  setPersonSkillRating(
+    personId: number,
+    skillId: number,
+    rating: number | null,
+  ): Promise<void>;
+
+  getPersonQualities(): Promise<PersonQualitiesRecord[]>;
+
+  setPersonQuality(
+    personId: number,
+    key: string,
+    rating: number | null,
+  ): Promise<void>;
+}

--- a/src/providers/SqlJsDbProvider.ts
+++ b/src/providers/SqlJsDbProvider.ts
@@ -1,0 +1,89 @@
+import type {
+  DbProvider,
+  PersonQualitiesRecord,
+  PersonSkillRating,
+  SqlExecute,
+  SqlQueryAll,
+  TrainingSkill,
+} from "./DbProvider";
+
+export class SqlJsDbProvider implements DbProvider {
+  public readonly kind = "sqljs" as const;
+
+  constructor(
+    private readonly queryAll: SqlQueryAll,
+    private readonly execute: SqlExecute,
+  ) {}
+
+  async getTrainingSkills(): Promise<TrainingSkill[]> {
+    const rows = this.queryAll(
+      `SELECT id, code, name, active, group_id FROM skill WHERE active=1 ORDER BY name`,
+    );
+    return rows.map((row: any) => ({
+      id: Number(row.id),
+      code: String(row.code ?? ""),
+      name: String(row.name ?? ""),
+      active: Number(row.active ?? 0),
+      groupId: row.group_id ?? null,
+    }));
+  }
+
+  async getPersonSkillRatings(): Promise<PersonSkillRating[]> {
+    const rows = this.queryAll(`SELECT person_id, skill_id, rating FROM person_skill`);
+    return rows.map((row: any) => ({
+      personId: Number(row.person_id),
+      skillId: Number(row.skill_id),
+      rating: Number(row.rating),
+    }));
+  }
+
+  async setPersonSkillRating(
+    personId: number,
+    skillId: number,
+    rating: number | null,
+  ): Promise<void> {
+    if (rating === null) {
+      this.execute(`DELETE FROM person_skill WHERE person_id=? AND skill_id=?`, [personId, skillId]);
+      return;
+    }
+    this.execute(
+      `INSERT INTO person_skill (person_id, skill_id, rating) VALUES (?,?,?)
+       ON CONFLICT(person_id, skill_id) DO UPDATE SET rating=excluded.rating`,
+      [personId, skillId, rating],
+    );
+  }
+
+  async getPersonQualities(): Promise<PersonQualitiesRecord[]> {
+    const rows = this.queryAll(`SELECT * FROM person_quality`);
+    return rows.map((row: any) => {
+      const { person_id, ...rest } = row;
+      const values: Record<string, number> = {};
+      for (const [key, value] of Object.entries(rest)) {
+        if (value == null) continue;
+        const numeric = Number(value);
+        if (!Number.isNaN(numeric)) values[key] = numeric;
+      }
+      return { personId: Number(person_id), values };
+    });
+  }
+
+  async setPersonQuality(
+    personId: number,
+    key: string,
+    rating: number | null,
+  ): Promise<void> {
+    if (rating === null) {
+      this.execute(`UPDATE person_quality SET ${key}=NULL WHERE person_id=?`, [personId]);
+      return;
+    }
+    this.execute(
+      `INSERT INTO person_quality (person_id, ${key}) VALUES (?, ?)
+       ON CONFLICT(person_id) DO UPDATE SET ${key}=excluded.${key}`,
+      [personId, rating],
+    );
+  }
+}
+
+export function createSqlJsDbProvider(all: SqlQueryAll, run: SqlExecute): SqlJsDbProvider {
+  return new SqlJsDbProvider(all, run);
+}

--- a/src/providers/factory.ts
+++ b/src/providers/factory.ts
@@ -1,0 +1,25 @@
+import { GraphSharePointProvider } from "./sharepoint/GraphSharePointProvider";
+import { createSqlJsDbProvider } from "./SqlJsDbProvider";
+import type { DbProvider, SqlExecute, SqlQueryAll } from "./DbProvider";
+import { isMsalConfigured } from "../services/msal";
+
+function useSharePointProvider(): boolean {
+  const flag = import.meta.env.VITE_FEATURE_SP_TRAINING;
+  return flag === "true" || flag === "1";
+}
+
+function getSharePointOptions() {
+  return {
+    siteId: import.meta.env.VITE_SHAREPOINT_SITE_ID,
+    skillsListId: import.meta.env.VITE_SHAREPOINT_SKILLS_LIST_ID,
+    personSkillsListId: import.meta.env.VITE_SHAREPOINT_PERSON_SKILLS_LIST_ID,
+    personQualitiesListId: import.meta.env.VITE_SHAREPOINT_PERSON_QUALITIES_LIST_ID,
+  };
+}
+
+export function createDbProvider(all: SqlQueryAll, run: SqlExecute): DbProvider {
+  if (useSharePointProvider() && isMsalConfigured()) {
+    return new GraphSharePointProvider(getSharePointOptions());
+  }
+  return createSqlJsDbProvider(all, run);
+}

--- a/src/providers/sharepoint/GraphSharePointProvider.ts
+++ b/src/providers/sharepoint/GraphSharePointProvider.ts
@@ -1,0 +1,171 @@
+import type {
+  DbProvider,
+  PersonQualitiesRecord,
+  PersonSkillRating,
+  TrainingSkill,
+} from "../DbProvider";
+import { acquireMsalToken, ensureMsalLogin, isMsalConfigured } from "../../services/msal";
+
+export interface SharePointProviderOptions {
+  siteId?: string;
+  skillsListId?: string;
+  personSkillsListId?: string;
+  personQualitiesListId?: string;
+  scopes?: string[];
+}
+
+interface SharePointListItem {
+  fields?: Record<string, unknown>;
+}
+
+interface SharePointListResponse {
+  value: SharePointListItem[];
+}
+
+const DEFAULT_SCOPES = ["https://graph.microsoft.com/.default"];
+
+export class GraphSharePointProvider implements DbProvider {
+  public readonly kind = "graph-sharepoint" as const;
+
+  private readonly options: Required<SharePointProviderOptions>;
+  private loginPromise: Promise<void> | null = null;
+
+  constructor(options: SharePointProviderOptions) {
+    this.options = {
+      siteId: options.siteId ?? "",
+      skillsListId: options.skillsListId ?? "",
+      personSkillsListId: options.personSkillsListId ?? "",
+      personQualitiesListId: options.personQualitiesListId ?? "",
+      scopes: options.scopes && options.scopes.length ? options.scopes : DEFAULT_SCOPES,
+    };
+  }
+
+  private isConfigured(): boolean {
+    return Boolean(
+      this.options.siteId &&
+      this.options.skillsListId &&
+      this.options.personSkillsListId &&
+      this.options.personQualitiesListId &&
+      isMsalConfigured(),
+    );
+  }
+
+  private async ensureLogin(): Promise<void> {
+    if (!this.isConfigured()) {
+      throw new Error("SharePoint provider is not fully configured.");
+    }
+    if (!this.loginPromise) {
+      this.loginPromise = ensureMsalLogin(this.options.scopes).catch((error) => {
+        this.loginPromise = null;
+        throw error;
+      });
+    }
+    await this.loginPromise;
+  }
+
+  private async graphFetch<T = SharePointListResponse>(path: string): Promise<T> {
+    await this.ensureLogin();
+    const token = await acquireMsalToken(this.options.scopes);
+    const response = await fetch(`https://graph.microsoft.com/v1.0${path}`, {
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+      },
+    });
+    if (!response.ok) {
+      throw new Error(`Graph request failed: ${response.status} ${response.statusText}`);
+    }
+    return (await response.json()) as T;
+  }
+
+  async getTrainingSkills(): Promise<TrainingSkill[]> {
+    if (!this.isConfigured()) {
+      console.warn("GraphSharePointProvider: configuration missing; returning empty skills list.");
+      return [];
+    }
+
+    try {
+      const data = await this.graphFetch<SharePointListResponse>(
+        `/sites/${this.options.siteId}/lists/${this.options.skillsListId}/items?expand=fields`,
+      );
+      return data.value.map((item) => {
+        const fields = item.fields ?? {};
+        const skill: TrainingSkill = {
+          id: Number(fields["Id"] ?? fields["id"] ?? 0),
+          code: String(fields["Code"] ?? fields["code"] ?? ""),
+          name: String(fields["Title"] ?? fields["Name"] ?? fields["title"] ?? ""),
+          active: fields["Active"] === false ? 0 : 1,
+          groupId: fields["GroupId"] != null ? Number(fields["GroupId"]) : null,
+        };
+        return skill;
+      });
+    } catch (error) {
+      console.error("GraphSharePointProvider.getTrainingSkills", error);
+      return [];
+    }
+  }
+
+  async getPersonSkillRatings(): Promise<PersonSkillRating[]> {
+    if (!this.isConfigured()) {
+      console.warn("GraphSharePointProvider: configuration missing; returning empty skill ratings.");
+      return [];
+    }
+
+    try {
+      const data = await this.graphFetch<SharePointListResponse>(
+        `/sites/${this.options.siteId}/lists/${this.options.personSkillsListId}/items?expand=fields`,
+      );
+      return data.value.map((item) => {
+        const fields = item.fields ?? {};
+        const rating: PersonSkillRating = {
+          personId: Number(fields["PersonId"] ?? fields["personId"] ?? 0),
+          skillId: Number(fields["SkillId"] ?? fields["skillId"] ?? 0),
+          rating: Number(fields["Rating"] ?? fields["rating"] ?? 0),
+        };
+        return rating;
+      });
+    } catch (error) {
+      console.error("GraphSharePointProvider.getPersonSkillRatings", error);
+      return [];
+    }
+  }
+
+  async setPersonSkillRating(): Promise<void> {
+    console.warn("GraphSharePointProvider.setPersonSkillRating is not implemented yet.");
+  }
+
+  async getPersonQualities(): Promise<PersonQualitiesRecord[]> {
+    if (!this.isConfigured()) {
+      console.warn("GraphSharePointProvider: configuration missing; returning empty qualities.");
+      return [];
+    }
+
+    try {
+      const data = await this.graphFetch<SharePointListResponse>(
+        `/sites/${this.options.siteId}/lists/${this.options.personQualitiesListId}/items?expand=fields`,
+      );
+      return data.value.map((item) => {
+        const fields = item.fields ?? {};
+        const personId = Number(fields["PersonId"] ?? fields["personId"] ?? 0);
+        const values: Record<string, number> = {};
+        for (const [key, value] of Object.entries(fields)) {
+          if (value == null) continue;
+          if (/PersonId/i.test(key)) continue;
+          const numeric = Number(value);
+          if (!Number.isNaN(numeric)) {
+            values[key] = numeric;
+          }
+        }
+        const record: PersonQualitiesRecord = { personId, values };
+        return record;
+      });
+    } catch (error) {
+      console.error("GraphSharePointProvider.getPersonQualities", error);
+      return [];
+    }
+  }
+
+  async setPersonQuality(): Promise<void> {
+    console.warn("GraphSharePointProvider.setPersonQuality is not implemented yet.");
+  }
+}

--- a/src/services/msal.ts
+++ b/src/services/msal.ts
@@ -1,0 +1,151 @@
+type Nullable<T> = T | null;
+
+interface AccountInfo {
+  readonly homeAccountId: string;
+  readonly username?: string;
+  readonly name?: string;
+}
+
+interface AuthenticationResult {
+  readonly accessToken: string;
+  readonly account: AccountInfo | null;
+}
+
+interface PublicClientApplication {
+  getAllAccounts(): AccountInfo[];
+  setActiveAccount(account: AccountInfo | null): void;
+  getActiveAccount(): AccountInfo | null;
+  loginPopup(request: { scopes: string[] }): Promise<AuthenticationResult>;
+  acquireTokenSilent(request: { scopes: string[]; account: AccountInfo }): Promise<AuthenticationResult>;
+  acquireTokenPopup(request: { scopes: string[]; account: AccountInfo }): Promise<AuthenticationResult>;
+}
+
+type PublicClientApplicationConstructor = new (config: {
+  auth: {
+    clientId: string;
+    authority?: string;
+    redirectUri?: string;
+  };
+  cache?: {
+    cacheLocation?: string;
+    storeAuthStateInCookie?: boolean;
+  };
+}) => PublicClientApplication;
+
+declare global {
+  interface Window {
+    msal?: {
+      PublicClientApplication?: PublicClientApplicationConstructor;
+    };
+  }
+}
+
+let msalInstance: Nullable<PublicClientApplication> = null;
+let loginInFlight: Promise<AccountInfo> | null = null;
+
+function getMsalConstructor(): PublicClientApplicationConstructor {
+  if (typeof window === "undefined") {
+    throw new Error("MSAL requires a browser environment.");
+  }
+  const ctor = window.msal?.PublicClientApplication;
+  if (!ctor) {
+    throw new Error(
+      "MSAL browser script not found. Include msal-browser or install @azure/msal-browser to enable authentication.",
+    );
+  }
+  return ctor;
+}
+
+function getClientId(): string | undefined {
+  const value = import.meta.env.VITE_AZURE_CLIENT_ID;
+  return value && value.length ? value : undefined;
+}
+
+function getAuthority(): string | undefined {
+  const authority = import.meta.env.VITE_AZURE_AUTHORITY;
+  if (authority && authority.length) return authority;
+  const tenantId = import.meta.env.VITE_AZURE_TENANT_ID;
+  if (tenantId && tenantId.length) {
+    return `https://login.microsoftonline.com/${tenantId}`;
+  }
+  return undefined;
+}
+
+function getRedirectUri(): string | undefined {
+  const redirect = import.meta.env.VITE_AZURE_REDIRECT_URI;
+  if (redirect && redirect.length) return redirect;
+  if (typeof window !== "undefined" && window.location) {
+    return window.location.origin;
+  }
+  return undefined;
+}
+
+export function isMsalConfigured(): boolean {
+  return Boolean(getClientId());
+}
+
+export function getMsalInstance(): PublicClientApplication {
+  const clientId = getClientId();
+  if (!clientId) {
+    throw new Error("MSAL is not configured. Set VITE_AZURE_CLIENT_ID in the environment.");
+  }
+  if (!msalInstance) {
+    const MsalCtor = getMsalConstructor();
+    msalInstance = new MsalCtor({
+      auth: {
+        clientId,
+        authority: getAuthority(),
+        redirectUri: getRedirectUri(),
+      },
+      cache: {
+        cacheLocation: "localStorage",
+        storeAuthStateInCookie: false,
+      },
+    });
+  }
+  return msalInstance;
+}
+
+export async function ensureMsalLogin(scopes: string[] = ["User.Read"]): Promise<AccountInfo> {
+  const instance = getMsalInstance();
+  const accounts = instance.getAllAccounts();
+  if (accounts.length > 0) {
+    const account = accounts[0]!;
+    instance.setActiveAccount(account);
+    return account;
+  }
+
+  if (!loginInFlight) {
+    loginInFlight = instance.loginPopup({ scopes }).then((result) => {
+      if (!result.account) {
+        throw new Error("MSAL login did not return an account.");
+      }
+      instance.setActiveAccount(result.account);
+      return result.account;
+    }).finally(() => {
+      loginInFlight = null;
+    });
+  }
+
+  return loginInFlight;
+}
+
+export async function acquireMsalToken(scopes: string[]): Promise<string> {
+  const instance = getMsalInstance();
+  const account = instance.getActiveAccount() ?? (await ensureMsalLogin(scopes));
+
+  try {
+    const response = await instance.acquireTokenSilent({ scopes, account });
+    if (!response.accessToken) {
+      throw new Error("MSAL silent token acquisition returned no access token.");
+    }
+    return response.accessToken;
+  } catch (error) {
+    console.warn("MSAL silent token acquisition failed; falling back to popup.", error);
+    const response = await instance.acquireTokenPopup({ scopes, account });
+    if (!response.accessToken) {
+      throw new Error("MSAL popup token acquisition returned no access token.");
+    }
+    return response.accessToken;
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a DbProvider interface plus SQL.js and Graph/SharePoint implementations with a factory switch
- add an MSAL helper service that instantiates PublicClientApplication when the browser script is present and env vars are set
- refactor Training view to consume the provider abstraction and respect the SharePoint feature flag

## Testing
- npm run build *(fails: `vite` not executable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c85737ac8c8322afdef8763d41379c