### PR TITLE
Fix dropdown option labels across training and admin views

### DIFF
--- a/src/components/AutoFillSettings.tsx
+++ b/src/components/AutoFillSettings.tsx
@@ -43,8 +43,12 @@ export default function AutoFillSettings({ open, onClose }: AutoFillSettingsProp
               selectedOptions={[priority]}
               onOptionSelect={(_, data) => setPriority(String(data.optionValue))}
             >
-              <Option value="trained">Trained first</Option>
-              <Option value="alphabetical">Alphabetical</Option>
+              <Option value="trained" text="Trained first">
+                Trained first
+              </Option>
+              <Option value="alphabetical" text="Alphabetical">
+                Alphabetical
+              </Option>
             </Dropdown>
           </DialogContent>
           <DialogActions>

--- a/src/components/AutoFillSettings.tsx
+++ b/src/components/AutoFillSettings.tsx
@@ -41,6 +41,7 @@ export default function AutoFillSettings({ open, onClose }: AutoFillSettingsProp
           <DialogContent>
             <Dropdown
               selectedOptions={[priority]}
+              value={priority === "alphabetical" ? "Alphabetical" : "Trained first"}
               onOptionSelect={(_, data) => setPriority(String(data.optionValue))}
             >
               <Option value="trained" text="Trained first">

--- a/src/components/AvailabilityOverrideManager.tsx
+++ b/src/components/AvailabilityOverrideManager.tsx
@@ -206,11 +206,14 @@ export default function AvailabilityOverrideManager({
           value={personId != null ? String(personId) : ""}
           onOptionSelect={(_, d) => setPersonId(Number(d.optionValue))}
         >
-          {people.map((p: any) => (
-            <Option key={p.id} value={String(p.id)}>
-              {p.first_name} {p.last_name}
-            </Option>
-          ))}
+          {people.map((p: any) => {
+            const label = `${p.first_name} ${p.last_name}`;
+            return (
+              <Option key={p.id} value={String(p.id)} text={label}>
+                {label}
+              </Option>
+            );
+          })}
         </Dropdown>
         <Input
           className={s.dateCol}
@@ -243,10 +246,18 @@ export default function AvailabilityOverrideManager({
                     })
                   }
                 >
-                  <Option value="U">Unavailable</Option>
-                  <Option value="AM">AM</Option>
-                  <Option value="PM">PM</Option>
-                  <Option value="B">Both</Option>
+                  <Option value="U" text="Unavailable">
+                    Unavailable
+                  </Option>
+                  <Option value="AM" text="AM">
+                    AM
+                  </Option>
+                  <Option value="PM" text="PM">
+                    PM
+                  </Option>
+                  <Option value="B" text="Both">
+                    Both
+                  </Option>
                 </Dropdown>
               </TableCell>
             ))}

--- a/src/components/CrewHistoryView.tsx
+++ b/src/components/CrewHistoryView.tsx
@@ -402,26 +402,33 @@ export default function CrewHistoryView({
           <div className={styles.stack}>
             <Label>Sort</Label>
             <Dropdown className={styles.full} selectedOptions={[sortField]} onOptionSelect={(_, data) => setSortField(data.optionValue as any)}>
-              <Option value="last">Last Name</Option>
-              <Option value="first">First Name</Option>
-              <Option value="brother_sister">B/S</Option>
-              <Option value="commuter">Commute</Option>
-              <Option value="active">Active</Option>
-              <Option value="avail_mon">Mon</Option>
-              <Option value="avail_tue">Tue</Option>
-              <Option value="avail_wed">Wed</Option>
-              <Option value="avail_thu">Thu</Option>
-              <Option value="avail_fri">Fri</Option>
-              {segmentNames.map((seg) => (
-                <Option key={seg} value={seg}>{`${seg} Role`}</Option>
-              ))}
+              <Option value="last" text="Last Name">Last Name</Option>
+              <Option value="first" text="First Name">First Name</Option>
+              <Option value="brother_sister" text="B/S">B/S</Option>
+              <Option value="commuter" text="Commute">Commute</Option>
+              <Option value="active" text="Active">Active</Option>
+              <Option value="avail_mon" text="Mon">Mon</Option>
+              <Option value="avail_tue" text="Tue">Tue</Option>
+              <Option value="avail_wed" text="Wed">Wed</Option>
+              <Option value="avail_thu" text="Thu">Thu</Option>
+              <Option value="avail_fri" text="Fri">Fri</Option>
+              {segmentNames.map((seg) => {
+                const label = `${seg} Role`;
+                return (
+                  <Option key={seg} value={seg} text={label}>
+                    {label}
+                  </Option>
+                );
+              })}
             </Dropdown>
           </div>
           <div className={styles.stack}>
             <Label>Filter month</Label>
             <Dropdown className={styles.full} selectedOptions={filterMonth ? [filterMonth] : []} onOptionSelect={(_, data) => setFilterMonth(data.optionValue as string)}>
               {months.map((m) => (
-                <Option key={m} value={m}>{m}</Option>
+                <Option key={m} value={m} text={m}>
+                  {m}
+                </Option>
               ))}
             </Dropdown>
           </div>
@@ -429,7 +436,9 @@ export default function CrewHistoryView({
             <Label>Role groups</Label>
             <Dropdown className={styles.full} multiselect placeholder="All Groups" selectedOptions={groupFilter} onOptionSelect={(_, data) => setGroupFilter(data.selectedOptions as string[])}>
               {groups.map((g) => (
-                <Option key={g.name} value={g.name}>{g.name}</Option>
+                <Option key={g.name} value={g.name} text={g.name}>
+                  {g.name}
+                </Option>
               ))}
             </Dropdown>
           </div>

--- a/src/components/CrewHistoryView.tsx
+++ b/src/components/CrewHistoryView.tsx
@@ -186,6 +186,32 @@ export default function CrewHistoryView({
   const [editPast, setEditPast] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
 
+  const sortFieldLabel = useMemo(() => {
+    const base: Record<string, string> = {
+      last: "Last Name",
+      first: "First Name",
+      brother_sister: "B/S",
+      commuter: "Commute",
+      active: "Active",
+      avail_mon: "Mon",
+      avail_tue: "Tue",
+      avail_wed: "Wed",
+      avail_thu: "Thu",
+      avail_fri: "Fri",
+    };
+    if (base[sortField]) return base[sortField];
+    if (segmentNames.includes(sortField as Segment)) {
+      return `${sortField} Role`;
+    }
+    return "";
+  }, [sortField, segmentNames]);
+
+  const filterMonthLabel = filterMonth ? filterMonth : "All Months";
+  const groupFilterLabel = useMemo(
+    () => (groupFilter.length ? groupFilter.join(", ") : "All Groups"),
+    [groupFilter],
+  );
+
   useEffect(() => {
     if (sqlDb) {
       setDefs(all(`SELECT * FROM monthly_default`));
@@ -401,7 +427,12 @@ export default function CrewHistoryView({
           <PeopleFiltersBar state={filters} onChange={(next) => setFilters((s) => ({ ...s, ...next }))} />
           <div className={styles.stack}>
             <Label>Sort</Label>
-            <Dropdown className={styles.full} selectedOptions={[sortField]} onOptionSelect={(_, data) => setSortField(data.optionValue as any)}>
+            <Dropdown
+              className={styles.full}
+              selectedOptions={[sortField]}
+              value={sortFieldLabel}
+              onOptionSelect={(_, data) => setSortField(data.optionValue as any)}
+            >
               <Option value="last" text="Last Name">Last Name</Option>
               <Option value="first" text="First Name">First Name</Option>
               <Option value="brother_sister" text="B/S">B/S</Option>
@@ -424,7 +455,14 @@ export default function CrewHistoryView({
           </div>
           <div className={styles.stack}>
             <Label>Filter month</Label>
-            <Dropdown className={styles.full} selectedOptions={filterMonth ? [filterMonth] : []} onOptionSelect={(_, data) => setFilterMonth(data.optionValue as string)}>
+            <Dropdown
+              className={styles.full}
+              placeholder="All Months"
+              selectedOptions={[filterMonth || ""]}
+              value={filterMonthLabel}
+              onOptionSelect={(_, data) => setFilterMonth((data.optionValue as string) || "")}
+            >
+              <Option value="" text="All Months">All Months</Option>
               {months.map((m) => (
                 <Option key={m} value={m} text={m}>
                   {m}
@@ -434,7 +472,14 @@ export default function CrewHistoryView({
           </div>
           <div className={styles.stack}>
             <Label>Role groups</Label>
-            <Dropdown className={styles.full} multiselect placeholder="All Groups" selectedOptions={groupFilter} onOptionSelect={(_, data) => setGroupFilter(data.selectedOptions as string[])}>
+            <Dropdown
+              className={styles.full}
+              multiselect
+              placeholder="All Groups"
+              selectedOptions={groupFilter}
+              value={groupFilterLabel}
+              onOptionSelect={(_, data) => setGroupFilter(data.selectedOptions as string[])}
+            >
               {groups.map((g) => (
                 <Option key={g.name} value={g.name} text={g.name}>
                   {g.name}

--- a/src/components/DailyRunBoard.tsx
+++ b/src/components/DailyRunBoard.tsx
@@ -1145,11 +1145,14 @@ export default function DailyRunBoard({
                   }}
                   style={{ width: "100%" }}
                 >
-                  {moveContext.targets.map((t) => (
-                    <Option key={t.role.id} value={String(t.role.id)}>
-                      {`${t.group.name} - ${t.role.name}${t.need>0?` (need ${t.need})`:''}`}
-                    </Option>
-                  ))}
+                  {moveContext.targets.map((t) => {
+                    const label = `${t.group.name} - ${t.role.name}${t.need>0?` (need ${t.need})`:''}`;
+                    return (
+                      <Option key={t.role.id} value={String(t.role.id)} text={label}>
+                        {label}
+                      </Option>
+                    );
+                  })}
                 </Dropdown>
               </DialogContent>
               <DialogActions>
@@ -1180,9 +1183,11 @@ export default function DailyRunBoard({
                       }}
                       style={{ width: "100%" }}
                     >
-                      <Option value="">None</Option>
+                      <Option value="" text="None">
+                        None
+                      </Option>
                       {s.candidates.map((c) => (
-                        <Option key={c.id} value={String(c.id)}>
+                        <Option key={c.id} value={String(c.id)} text={c.label}>
                           {c.label}
                         </Option>
                       ))}

--- a/src/components/DailyRunBoard.tsx
+++ b/src/components/DailyRunBoard.tsx
@@ -252,6 +252,14 @@ export default function DailyRunBoard({
     Array<{ role: any; group: any; candidates: Array<{ id: number; label: string }>; selected: number | null }>
   >([]);
 
+  const moveSelectedLabel = useMemo(() => {
+    if (!moveContext || moveTargetId == null) return "";
+    const target = moveContext.targets.find((t) => t.role.id === moveTargetId);
+    if (!target) return "";
+    const needSuffix = target.need > 0 ? ` (need ${target.need})` : "";
+    return `${target.group.name} - ${target.role.name}${needSuffix}`;
+  }, [moveContext, moveTargetId]);
+
   const roles = useMemo(() => roleListForSegment(seg), [roleListForSegment, seg]);
 
   useEffect(() => {
@@ -912,6 +920,27 @@ export default function DailyRunBoard({
     const [addSel, setAddSel] = useState<string[]>([]);
     const [openAdd, setOpenAdd] = useState(false);
 
+    const formatCandidateLabel = useCallback(
+      (candidate: { id: number; label: string }) => {
+        const info = overlapByPerson.get(candidate.id);
+        const parts: string[] = [];
+        if (info?.heavy) parts.push("(Time-off)");
+        else if (info?.partial) parts.push("(Partial Time-off)");
+        const curRoleId = personAssignedRoleMap.get(candidate.id);
+        const curStatus = curRoleId != null ? roleStatusById.get(curRoleId) : undefined;
+        if (curStatus === "under" || curStatus === "exact") parts.push("(Assigned)");
+        const suffix = parts.length ? ` ${parts.join(' ')}` : "";
+        return `${candidate.label}${suffix}`;
+      },
+      [overlapByPerson, personAssignedRoleMap, roleStatusById],
+    );
+
+    const addSelectedLabel = useMemo(() => {
+      if (addSel.length === 0) return "";
+      const selected = sortedOpts.find((o) => String(o.id) === addSel[0]);
+      return selected ? formatCandidateLabel(selected) : "";
+    }, [addSel, sortedOpts, formatCandidateLabel]);
+
     const { bg: groupBg, fg: groupFg } = themeColors(group.theme);
 
     return (
@@ -954,6 +983,7 @@ export default function DailyRunBoard({
             open={openAdd}
             onOpenChange={(_, d) => setOpenAdd(Boolean(d.open))}
             selectedOptions={addSel}
+            value={addSelectedLabel}
             onOptionSelect={(_, data) => {
               const val = data.optionValue ?? '';
               if (!val) return;
@@ -981,14 +1011,15 @@ export default function DailyRunBoard({
                 const curStatus = curRoleId != null ? roleStatusById.get(curRoleId) : undefined;
                 if (curStatus === "under" || curStatus === "exact") parts.push("(Assigned)");
                 const suffix = parts.length ? ` ${parts.join(' ')}` : "";
+                const text = formatCandidateLabel(o);
                 return (
                   <Option
                     key={o.id}
                     value={String(o.id)}
                     disabled={isHeavy}
-                    text={`${o.label}${suffix}`}
+                    text={text}
                   >
-                    {`${o.label}${suffix}`}
+                    {text}
                   </Option>
                 );
               })}
@@ -1139,6 +1170,7 @@ export default function DailyRunBoard({
                 <Dropdown
                   placeholder="Select destination"
                   selectedOptions={moveTargetId != null ? [String(moveTargetId)] : []}
+                  value={moveSelectedLabel}
                   onOptionSelect={(_, data) => {
                     const v = data.optionValue ?? data.optionText;
                     setMoveTargetId(v ? Number(v) : null);
@@ -1170,30 +1202,37 @@ export default function DailyRunBoard({
               <DialogTitle>Auto-Fill Suggestions</DialogTitle>
               <DialogContent>
                 {autoFillSuggestions.length === 0 && <Body1>No suggestions available.</Body1>}
-                {autoFillSuggestions.map((s, idx) => (
-                  <div key={s.role.id} style={{ marginBottom: tokens.spacingVerticalS }}>
-                    <Subtitle2>{`${s.group.name} - ${s.role.name}`}</Subtitle2>
-                    <Dropdown
-                      selectedOptions={s.selected != null ? [String(s.selected)] : [""]}
-                      onOptionSelect={(_, data) => {
-                        const val = data.optionValue ? Number(data.optionValue) : null;
-                        setAutoFillSuggestions((prev) =>
-                          prev.map((p, i) => (i === idx ? { ...p, selected: val } : p))
-                        );
-                      }}
-                      style={{ width: "100%" }}
-                    >
-                      <Option value="" text="None">
-                        None
-                      </Option>
-                      {s.candidates.map((c) => (
-                        <Option key={c.id} value={String(c.id)} text={c.label}>
-                          {c.label}
+                {autoFillSuggestions.map((s, idx) => {
+                  const selectedLabel =
+                    s.selected != null
+                      ? s.candidates.find((c) => c.id === s.selected)?.label ?? ""
+                      : "None";
+                  return (
+                    <div key={s.role.id} style={{ marginBottom: tokens.spacingVerticalS }}>
+                      <Subtitle2>{`${s.group.name} - ${s.role.name}`}</Subtitle2>
+                      <Dropdown
+                        selectedOptions={s.selected != null ? [String(s.selected)] : [""]}
+                        value={selectedLabel}
+                        onOptionSelect={(_, data) => {
+                          const val = data.optionValue ? Number(data.optionValue) : null;
+                          setAutoFillSuggestions((prev) =>
+                            prev.map((p, i) => (i === idx ? { ...p, selected: val } : p))
+                          );
+                        }}
+                        style={{ width: "100%" }}
+                      >
+                        <Option value="" text="None">
+                          None
                         </Option>
-                      ))}
-                    </Dropdown>
-                  </div>
-                ))}
+                        {s.candidates.map((c) => (
+                          <Option key={c.id} value={String(c.id)} text={c.label}>
+                            {c.label}
+                          </Option>
+                        ))}
+                      </Dropdown>
+                    </div>
+                  );
+                })}
               </DialogContent>
               <DialogActions>
                 <Button onClick={cancelAutoFill}>Cancel</Button>

--- a/src/components/DailyRunBoard.tsx
+++ b/src/components/DailyRunBoard.tsx
@@ -1174,7 +1174,7 @@ export default function DailyRunBoard({
                   <div key={s.role.id} style={{ marginBottom: tokens.spacingVerticalS }}>
                     <Subtitle2>{`${s.group.name} - ${s.role.name}`}</Subtitle2>
                     <Dropdown
-                      selectedOptions={s.selected != null ? [String(s.selected)] : []}
+                      selectedOptions={s.selected != null ? [String(s.selected)] : [""]}
                       onOptionSelect={(_, data) => {
                         const val = data.optionValue ? Number(data.optionValue) : null;
                         setAutoFillSuggestions((prev) =>

--- a/src/components/ExportGroupEditor.tsx
+++ b/src/components/ExportGroupEditor.tsx
@@ -14,6 +14,10 @@ export default function ExportGroupEditor({ all, run, refresh }: ExportGroupEdit
   const [editing, setEditing] = useState<any | null>(null);
   const [formVisible, setFormVisible] = useState(false);
   const [form, setForm] = useState<any>(empty);
+  const selectedGroupLabel =
+    form.group_id === ""
+      ? ""
+      : available.find((g:any) => g.id === Number(form.group_id))?.name || "";
 
   function load() {
     const r = all(`SELECT eg.group_id, g.name as group_name, eg.code, eg.color, eg.column_group
@@ -133,6 +137,7 @@ export default function ExportGroupEditor({ all, run, refresh }: ExportGroupEdit
                 key={`export-group-${available.map((g:any)=>`${g.id}:${g.name}`).join(',')}-${form.group_id}`}
                 placeholder="Select group…"
                 selectedOptions={form.group_id ? [String(form.group_id)] : []}
+                value={selectedGroupLabel}
                 onOptionSelect={(_, data) => setForm({ ...form, group_id: Number(data.optionValue ?? data.optionText) })}
               >
                 {available.map((g:any)=>(

--- a/src/components/MonthlyDefaults.tsx
+++ b/src/components/MonthlyDefaults.tsx
@@ -111,6 +111,25 @@ export default function MonthlyDefaults({
   const [filters, setFilters] = useState<PeopleFiltersState>(() => freshPeopleFilters());
   const [sortKey, setSortKey] = useState<string>("name");
   const [sortDir, setSortDir] = useState<"asc" | "desc">("asc");
+  const sortKeyLabel = useMemo(() => {
+    const base: Record<string, string> = {
+      name: "Name",
+      email: "Email",
+      brother_sister: "B/S",
+      commuter: "Commute",
+      active: "Active",
+      avail_mon: "Mon",
+      avail_tue: "Tue",
+      avail_wed: "Wed",
+      avail_thu: "Thu",
+      avail_fri: "Fri",
+    };
+    if (base[sortKey]) return base[sortKey];
+    if (segmentNames.includes(sortKey as Segment)) {
+      return `${sortKey} Role`;
+    }
+    return "";
+  }, [sortKey, segmentNames]);
   const [weekdayPerson, setWeekdayPerson] = useState<number | null>(null);
   const [notePerson, setNotePerson] = useState<number | null>(null);
 
@@ -239,8 +258,13 @@ export default function MonthlyDefaults({
           <Input className={styles.field} type="month" value={copyFromMonth} onChange={(_, d) => setCopyFromMonth(d.value)} />
           </div>
           <div>
-            <span className={styles.label}>Sort by</span>
-            <Dropdown className={styles.field} selectedOptions={[sortKey]} onOptionSelect={(_, data) => setSortKey(data.optionValue as any)}>
+          <span className={styles.label}>Sort by</span>
+            <Dropdown
+              className={styles.field}
+              selectedOptions={[sortKey]}
+              value={sortKeyLabel}
+              onOptionSelect={(_, data) => setSortKey(data.optionValue as any)}
+            >
           <Option value="name" text="Name">Name</Option>
           <Option value="email" text="Email">Email</Option>
           <Option value="brother_sister" text="B/S">B/S</Option>

--- a/src/components/RoleEditor.tsx
+++ b/src/components/RoleEditor.tsx
@@ -140,7 +140,11 @@ export default function RoleEditor({ all, run, refresh, segments }: RoleEditorPr
           <Field label="Group">
             <Dropdown
               key={`role-group-${editing?.id ?? 'new'}-${groups.map((g:any)=>`${g.id}:${g.name}`).join(',')}-${editing.group_id}`}
-              selectedOptions={[String(editing.group_id)]}
+              selectedOptions={editing.group_id != null ? [String(editing.group_id)] : []}
+              value={(() => {
+                const group = groups.find((g:any) => g.id === editing.group_id);
+                return group ? group.name : "";
+              })()}
               onOptionSelect={(_, data) => {
                 const v = Number(data.optionValue ?? data.optionText);
                 setEditing({ ...editing, group_id: v });

--- a/src/components/SegmentAdjustmentEditor.tsx
+++ b/src/components/SegmentAdjustmentEditor.tsx
@@ -53,6 +53,15 @@ export default function SegmentAdjustmentEditor({ all, run, refresh, segments }:
   const [formVisible, setFormVisible] = useState(false);
   const [form, setForm] = useState<typeof empty>(empty);
   const [roles, setRoles] = useState<any[]>([]);
+  const conditionRoleLabel = useMemo(() => {
+    if (form.condition_role_id == null) return "Any";
+    const role = roles.find((ro: any) => ro.id === form.condition_role_id);
+    return role ? role.name : "";
+  }, [form.condition_role_id, roles]);
+  const baselineLabel = useMemo(() => {
+    const match = baselineOpts.find((o) => o.value === form.baseline);
+    return match ? match.label : "";
+  }, [form.baseline]);
 
   const condSeg = segments.find((s) => s.name === form.condition_segment);
   const targetSeg = segments.find((s) => s.name === form.target_segment);
@@ -235,6 +244,7 @@ export default function SegmentAdjustmentEditor({ all, run, refresh, segments }:
             <Field label="Condition Segment" className={s.flex1}>
               <Dropdown
                 selectedOptions={[form.condition_segment]}
+                value={form.condition_segment}
                 onOptionSelect={(_, d) => setForm({ ...form, condition_segment: d.optionValue })}
               >
                 {segments.map((sg) => (
@@ -247,6 +257,7 @@ export default function SegmentAdjustmentEditor({ all, run, refresh, segments }:
             <Field label="Condition Role" className={s.flex1}>
               <Dropdown
                 selectedOptions={[form.condition_role_id == null ? "" : String(form.condition_role_id)]}
+                value={conditionRoleLabel}
                 onOptionSelect={(_, d) =>
                   setForm({ ...form, condition_role_id: d.optionValue ? Number(d.optionValue) : null })
                 }
@@ -264,6 +275,7 @@ export default function SegmentAdjustmentEditor({ all, run, refresh, segments }:
             <Field label="Target Segment" className={s.flex1}>
               <Dropdown
                 selectedOptions={[form.target_segment]}
+                value={form.target_segment}
                 onOptionSelect={(_, d) => setForm({ ...form, target_segment: d.optionValue })}
               >
                 {segments.map((sg) => (
@@ -276,6 +288,7 @@ export default function SegmentAdjustmentEditor({ all, run, refresh, segments }:
             <Field label="Field" className={s.flex1}>
               <Dropdown
                 selectedOptions={[form.target_field]}
+                value={form.target_field}
                 onOptionSelect={(_, d) =>
                   setForm({ ...form, target_field: d.optionValue as "start" | "end" })
                 }
@@ -293,6 +306,7 @@ export default function SegmentAdjustmentEditor({ all, run, refresh, segments }:
             <Field label="Baseline" className={s.flex1}>
               <Dropdown
                 selectedOptions={[form.baseline]}
+                value={baselineLabel}
                 onOptionSelect={(_, d) =>
                   setForm({ ...form, baseline: d.optionValue as SegmentAdjustmentRow["baseline"] })
                 }

--- a/src/components/SegmentAdjustmentEditor.tsx
+++ b/src/components/SegmentAdjustmentEditor.tsx
@@ -238,7 +238,7 @@ export default function SegmentAdjustmentEditor({ all, run, refresh, segments }:
                 onOptionSelect={(_, d) => setForm({ ...form, condition_segment: d.optionValue })}
               >
                 {segments.map((sg) => (
-                  <Option key={sg.name} value={sg.name}>
+                  <Option key={sg.name} value={sg.name} text={sg.name}>
                     {sg.name}
                   </Option>
                 ))}
@@ -251,9 +251,11 @@ export default function SegmentAdjustmentEditor({ all, run, refresh, segments }:
                   setForm({ ...form, condition_role_id: d.optionValue ? Number(d.optionValue) : null })
                 }
               >
-                <Option value="">Any</Option>
+                <Option value="" text="Any">
+                  Any
+                </Option>
                 {roles.map((ro: any) => (
-                  <Option key={ro.id} value={String(ro.id)}>
+                  <Option key={ro.id} value={String(ro.id)} text={ro.name}>
                     {ro.name}
                   </Option>
                 ))}
@@ -265,7 +267,7 @@ export default function SegmentAdjustmentEditor({ all, run, refresh, segments }:
                 onOptionSelect={(_, d) => setForm({ ...form, target_segment: d.optionValue })}
               >
                 {segments.map((sg) => (
-                  <Option key={sg.name} value={sg.name}>
+                  <Option key={sg.name} value={sg.name} text={sg.name}>
                     {sg.name}
                   </Option>
                 ))}
@@ -278,8 +280,12 @@ export default function SegmentAdjustmentEditor({ all, run, refresh, segments }:
                   setForm({ ...form, target_field: d.optionValue as "start" | "end" })
                 }
               >
-                <Option value="start">start</Option>
-                <Option value="end">end</Option>
+                <Option value="start" text="start">
+                  start
+                </Option>
+                <Option value="end" text="end">
+                  end
+                </Option>
               </Dropdown>
             </Field>
           </div>
@@ -292,7 +298,7 @@ export default function SegmentAdjustmentEditor({ all, run, refresh, segments }:
                 }
               >
                 {baselineOpts.map((o) => (
-                  <Option key={o.value} value={o.value}>
+                  <Option key={o.value} value={o.value} text={o.label}>
                     {o.label}
                   </Option>
                 ))}

--- a/src/components/SkillsEditor.tsx
+++ b/src/components/SkillsEditor.tsx
@@ -146,7 +146,7 @@ export default function SkillsEditor({ all, run, refresh }: SkillsEditorProps) {
           }}
         >
           {groups.map(g => (
-            <Option key={g.id} value={String(g.id)}>{g.name}</Option>
+            <Option key={g.id} value={String(g.id)} text={g.name}>{g.name}</Option>
           ))}
         </Dropdown>
   <Button appearance="primary" onClick={addSkill} disabled={!canAdd}>Add</Button>
@@ -177,9 +177,9 @@ export default function SkillsEditor({ all, run, refresh }: SkillsEditorProps) {
                       setRowGroup(r.id, val as any);
                     }}
                   >
-                    <Option value="">Unassigned</Option>
+                    <Option value="" text="Unassigned">Unassigned</Option>
                     {groups.map(g => (
-                      <Option key={g.id} value={String(g.id)}>{g.name}</Option>
+                      <Option key={g.id} value={String(g.id)} text={g.name}>{g.name}</Option>
                     ))}
                   </Dropdown>
                 </TableCell>

--- a/src/components/SkillsEditor.tsx
+++ b/src/components/SkillsEditor.tsx
@@ -28,6 +28,11 @@ export default function SkillsEditor({ all, run, refresh }: SkillsEditorProps) {
   const [name, setName] = React.useState("");
   const [groups, setGroups] = React.useState<GroupRow[]>([]);
   const [groupId, setGroupId] = React.useState<number | "">("");
+  const addGroupLabel = React.useMemo(() => {
+    if (groupId === "") return "Select group";
+    const match = groups.find((g) => g.id === Number(groupId));
+    return match ? match.name : "";
+  }, [groupId, groups]);
   const canAdd = React.useMemo(() => {
     return code.trim().length > 0 && name.trim().length > 0 && groupId !== "";
   }, [code, name, groupId]);
@@ -140,11 +145,13 @@ export default function SkillsEditor({ all, run, refresh }: SkillsEditorProps) {
         <Input className={s.name} placeholder="Name" value={name} onChange={(_,d)=>setName(d.value)} />
         <Dropdown className={s.groupSel}
           selectedOptions={groupId === "" ? [""] : [String(groupId)]}
+          value={addGroupLabel}
           onOptionSelect={(_, data) => {
             const val = data.optionValue ? parseInt(String(data.optionValue)) : "";
             setGroupId(val as any);
           }}
         >
+          <Option value="" text="Select group">Select group</Option>
           {groups.map(g => (
             <Option key={g.id} value={String(g.id)} text={g.name}>{g.name}</Option>
           ))}
@@ -172,6 +179,7 @@ export default function SkillsEditor({ all, run, refresh }: SkillsEditorProps) {
                   <Dropdown
                     className={s.groupSel}
                     selectedOptions={r.group_id == null ? [""] : [String(r.group_id)]}
+                    value={r.group_id == null ? "Unassigned" : (groups.find((g) => g.id === r.group_id)?.name || "")}
                     onOptionSelect={(_, data) => {
                       const val = data.optionValue ? parseInt(String(data.optionValue)) : "";
                       setRowGroup(r.id, val as any);

--- a/src/components/SkillsEditor.tsx
+++ b/src/components/SkillsEditor.tsx
@@ -139,7 +139,7 @@ export default function SkillsEditor({ all, run, refresh }: SkillsEditorProps) {
         <Input className={s.code} placeholder="Code" value={code} onChange={(_,d)=>setCode(d.value)} />
         <Input className={s.name} placeholder="Name" value={name} onChange={(_,d)=>setName(d.value)} />
         <Dropdown className={s.groupSel}
-          selectedOptions={groupId === "" ? [] : [String(groupId)]}
+          selectedOptions={groupId === "" ? [""] : [String(groupId)]}
           onOptionSelect={(_, data) => {
             const val = data.optionValue ? parseInt(String(data.optionValue)) : "";
             setGroupId(val as any);
@@ -171,7 +171,7 @@ export default function SkillsEditor({ all, run, refresh }: SkillsEditorProps) {
                 <TableCell>
                   <Dropdown
                     className={s.groupSel}
-                    selectedOptions={r.group_id == null ? [] : [String(r.group_id)]}
+                    selectedOptions={r.group_id == null ? [""] : [String(r.group_id)]}
                     onOptionSelect={(_, data) => {
                       const val = data.optionValue ? parseInt(String(data.optionValue)) : "";
                       setRowGroup(r.id, val as any);

--- a/src/components/TimeOffManager.tsx
+++ b/src/components/TimeOffManager.tsx
@@ -129,6 +129,11 @@ export default function TimeOffManager({ all, run, refresh }: TimeOffManagerProp
   const [addEndDate, setAddEndDate] = React.useState<string>("");
   const [addEndTime, setAddEndTime] = React.useState<string>("17:00");
   const [addReason, setAddReason] = React.useState<string>("");
+  const addPersonLabel = React.useMemo(() => {
+    if (addPersonId == null) return "Select person";
+    const match = people.find((p: any) => p.id === addPersonId);
+    return match ? `${match.last_name}, ${match.first_name}` : "";
+  }, [addPersonId, people]);
   // Always query fresh so the table updates after changes
   const rows = all(`SELECT t.id, t.person_id, t.start_ts, t.end_ts, t.reason, p.first_name, p.last_name, p.work_email FROM timeoff t JOIN person p ON p.id=t.person_id ORDER BY t.start_ts DESC LIMIT 200`);
 
@@ -341,6 +346,7 @@ export default function TimeOffManager({ all, run, refresh }: TimeOffManagerProp
           <Dropdown
             placeholder="Select person"
             selectedOptions={addPersonId!=null?[String(addPersonId)]:[]}
+            value={addPersonLabel}
             onOptionSelect={(_,d)=>{ const v = d.optionValue ?? d.optionText; setAddPersonId(v?Number(v):null); }}
           >
             {people.map((p:any)=> {

--- a/src/components/TimeOffManager.tsx
+++ b/src/components/TimeOffManager.tsx
@@ -343,9 +343,12 @@ export default function TimeOffManager({ all, run, refresh }: TimeOffManagerProp
             selectedOptions={addPersonId!=null?[String(addPersonId)]:[]}
             onOptionSelect={(_,d)=>{ const v = d.optionValue ?? d.optionText; setAddPersonId(v?Number(v):null); }}
           >
-            {people.map((p:any)=> (
-              <Option key={p.id} value={String(p.id)}>{`${p.last_name}, ${p.first_name}`}</Option>
-            ))}
+            {people.map((p:any)=> {
+              const label = `${p.last_name}, ${p.first_name}`;
+              return (
+                <Option key={p.id} value={String(p.id)} text={label}>{label}</Option>
+              );
+            })}
           </Dropdown>
         </div>
         <div className={s.col3}>

--- a/src/components/Training.tsx
+++ b/src/components/Training.tsx
@@ -621,7 +621,7 @@ export default function Training({
         <div className={s.groupCell}>
           <Label>{view === "qualities" ? "Role group" : "Skill group"}</Label>
           <Dropdown
-            selectedOptions={groupId === "" ? [] : [String(groupId)]}
+            selectedOptions={groupId === "" ? [""] : [String(groupId)]}
             onOptionSelect={(_, data) => {
               const val = data.optionValue ? parseInt(String(data.optionValue)) : "";
               setGroupId(val as any);
@@ -964,7 +964,7 @@ export default function Training({
                         <td key={sk.id} className={s.cell}>
                           <Dropdown
                             className={s.cellDropdown}
-                            selectedOptions={rating ? [String(rating)] : []}
+                            selectedOptions={rating != null ? [String(rating)] : [""]}
                             onOptionSelect={(_, data) => {
                               const val = parseInt(String(data.optionValue ?? data.optionText));
                               if (!val) setRating(p.id, sk.id, null);
@@ -1021,7 +1021,7 @@ export default function Training({
                         <td key={q.key} className={s.cell}>
                           <Dropdown
                             className={s.cellDropdown}
-                            selectedOptions={rating ? [String(rating)] : []}
+                            selectedOptions={rating != null ? [String(rating)] : [""]}
                             onOptionSelect={(_, data) => {
                               const val = parseInt(String(data.optionValue ?? data.optionText));
                               if (!val) setQuality(p.id, q.key, null);

--- a/src/components/Training.tsx
+++ b/src/components/Training.tsx
@@ -93,6 +93,11 @@ export default function Training({
   const [qualities, setQualities] = useState<Record<number, Record<string, number>>>({});
   const [groupId, setGroupId] = useState<number | "">("");
   const [filters, setFilters] = useState<PeopleFiltersState>(() => freshPeopleFilters({ activeOnly: true }));
+  const groupLabel = useMemo(() => {
+    if (groupId === "") return "All Groups";
+    const match = groups.find((g: any) => g.id === Number(groupId));
+    return match ? match.name : "";
+  }, [groupId, groups]);
 
   // Load skill catalog and person_skill ratings
   useEffect(() => {
@@ -622,6 +627,7 @@ export default function Training({
           <Label>{view === "qualities" ? "Role group" : "Skill group"}</Label>
           <Dropdown
             selectedOptions={groupId === "" ? [""] : [String(groupId)]}
+            value={groupLabel}
             onOptionSelect={(_, data) => {
               const val = data.optionValue ? parseInt(String(data.optionValue)) : "";
               setGroupId(val as any);
@@ -965,6 +971,7 @@ export default function Training({
                           <Dropdown
                             className={s.cellDropdown}
                             selectedOptions={rating != null ? [String(rating)] : [""]}
+                            value={rating != null ? String(rating) : "-"}
                             onOptionSelect={(_, data) => {
                               const val = parseInt(String(data.optionValue ?? data.optionText));
                               if (!val) setRating(p.id, sk.id, null);
@@ -1022,6 +1029,7 @@ export default function Training({
                           <Dropdown
                             className={s.cellDropdown}
                             selectedOptions={rating != null ? [String(rating)] : [""]}
+                            value={rating != null ? String(rating) : "-"}
                             onOptionSelect={(_, data) => {
                               const val = parseInt(String(data.optionValue ?? data.optionText));
                               if (!val) setQuality(p.id, q.key, null);

--- a/src/components/Training.tsx
+++ b/src/components/Training.tsx
@@ -627,9 +627,11 @@ export default function Training({
               setGroupId(val as any);
             }}
           >
-            <Option value="">All Groups</Option>
+            <Option value="" text="All Groups">
+              All Groups
+            </Option>
             {groups.map((g: any) => (
-              <Option key={g.id} value={String(g.id)}>
+              <Option key={g.id} value={String(g.id)} text={g.name}>
                 {g.name}
               </Option>
             ))}
@@ -969,12 +971,24 @@ export default function Training({
                               else setRating(p.id, sk.id, val);
                             }}
                           >
-                            <Option value="">-</Option>
-                            <Option value="1">1</Option>
-                            <Option value="2">2</Option>
-                            <Option value="3">3</Option>
-                            <Option value="4">4</Option>
-                            <Option value="5">5</Option>
+                            <Option value="" text="-">
+                              -
+                            </Option>
+                            <Option value="1" text="1">
+                              1
+                            </Option>
+                            <Option value="2" text="2">
+                              2
+                            </Option>
+                            <Option value="3" text="3">
+                              3
+                            </Option>
+                            <Option value="4" text="4">
+                              4
+                            </Option>
+                            <Option value="5" text="5">
+                              5
+                            </Option>
                           </Dropdown>
                         </td>
                       );
@@ -1014,12 +1028,24 @@ export default function Training({
                               else setQuality(p.id, q.key, val);
                             }}
                           >
-                            <Option value="">-</Option>
-                            <Option value="1">1</Option>
-                            <Option value="2">2</Option>
-                            <Option value="3">3</Option>
-                            <Option value="4">4</Option>
-                            <Option value="5">5</Option>
+                            <Option value="" text="-">
+                              -
+                            </Option>
+                            <Option value="1" text="1">
+                              1
+                            </Option>
+                            <Option value="2" text="2">
+                              2
+                            </Option>
+                            <Option value="3" text="3">
+                              3
+                            </Option>
+                            <Option value="4" text="4">
+                              4
+                            </Option>
+                            <Option value="5" text="5">
+                              5
+                            </Option>
                           </Dropdown>
                         </td>
                       );

--- a/src/components/filters/PeopleFilters.tsx
+++ b/src/components/filters/PeopleFilters.tsx
@@ -22,6 +22,23 @@ export const defaultPeopleFilters: PeopleFiltersState = {
   availMode: "any",
 };
 
+const genderLabel = (gender: Gender) => {
+  switch (gender) {
+    case "Brother":
+      return "Brother";
+    case "Sister":
+      return "Sister";
+    default:
+      return "All";
+  }
+};
+
+const availModeLabels: Record<PeopleFiltersState["availMode"], string> = {
+  any: "Any selected days",
+  all: "All selected days",
+  only: "Only selected days",
+};
+
 export function freshPeopleFilters(overrides: Partial<PeopleFiltersState> = {}): PeopleFiltersState {
   return {
     text: "",
@@ -179,6 +196,7 @@ export function PeopleFiltersBar({
                 className={s.field}
                 placeholder="All"
                 selectedOptions={state.gender ? [state.gender] : []}
+                value={genderLabel(state.gender)}
                 onOptionSelect={(_, data) => onChange({ gender: (data.optionValue as Gender) || "" })}
               >
                 <Option value="" text="All">All</Option>
@@ -218,6 +236,7 @@ export function PeopleFiltersBar({
               <Dropdown
                 className={s.field}
                 selectedOptions={[state.availMode]}
+                value={availModeLabels[state.availMode]}
                 onOptionSelect={(_, data) => onChange({ availMode: (data.optionValue as "any" | "all" | "only") || "any" })}
               >
                 <Option value="any" text="Any selected days">Any selected days</Option>


### PR DESCRIPTION
## Summary
- add `text` labels to Fluent UI dropdown options so selections render in the skills catalog and training matrix
- extend the same fix to other dropdowns (availability overrides, crew history filters, auto-fill, move dialog, time off, etc.) to keep their values visible

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c99ec7eb1c8322b96b085130df939d