### PR TITLE
Fix makeStyles usage to restore Admin view

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -98,6 +98,143 @@ async function loadXLSX(){
   return mod as any;
 }
 
+const useRequiredCellStyles = makeStyles({
+  row: { display: 'flex', alignItems: 'center', gap: tokens.spacingHorizontalS },
+  input: { width: '7ch' },
+});
+
+const useBaselineViewStyles = makeStyles({
+  root: { padding: tokens.spacingHorizontalM },
+  title: { fontWeight: tokens.fontWeightSemibold, fontSize: tokens.fontSizeBase400, marginBottom: tokens.spacingVerticalM },
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: '1fr',
+    gap: tokens.spacingHorizontalM,
+    ['@media (min-width: 1024px)']: { gridTemplateColumns: 'repeat(2, 1fr)' },
+    ['@media (min-width: 1280px)']: { gridTemplateColumns: 'repeat(3, 1fr)' },
+  },
+  card: {
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderRadius: tokens.borderRadiusLarge,
+    padding: tokens.spacingHorizontalM,
+    backgroundColor: tokens.colorNeutralBackground1,
+    boxShadow: tokens.shadow2,
+  },
+  roleCard: {
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderRadius: tokens.borderRadiusLarge,
+    padding: tokens.spacingHorizontalM,
+    marginBottom: tokens.spacingVerticalM,
+  },
+  roleGrid: {
+    display: 'grid',
+    gap: tokens.spacingHorizontalS,
+    gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))',
+    alignItems: 'start',
+  },
+  subTitle: { fontWeight: tokens.fontWeightSemibold, marginBottom: tokens.spacingVerticalS },
+  label: { fontSize: tokens.fontSizeBase200, color: tokens.colorNeutralForeground3, marginBottom: tokens.spacingVerticalXS },
+});
+
+const usePeopleEditorStyles = makeStyles({
+  root: { padding: tokens.spacingHorizontalM },
+  tableWrap: {
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderRadius: tokens.borderRadiusLarge,
+    overflowY: 'auto',
+    overflowX: 'hidden',
+    maxHeight: '60vh',
+    width: '100%',
+    boxShadow: tokens.shadow2,
+  },
+  header: { display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: tokens.spacingVerticalS },
+  title: { fontWeight: tokens.fontWeightSemibold, fontSize: tokens.fontSizeBase400 },
+  actions: { display: 'flex', gap: tokens.spacingHorizontalS },
+  formGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(12, 1fr)',
+    gap: tokens.spacingHorizontalS,
+    marginBottom: tokens.spacingVerticalM,
+  },
+  col2: { gridColumn: 'span 2' },
+  col3: { gridColumn: 'span 3' },
+  col4: { gridColumn: 'span 4' },
+  col6: { gridColumn: 'span 6' },
+  centerRow: { display: 'flex', alignItems: 'center' },
+  smallLabel: { color: tokens.colorNeutralForeground3, marginBottom: tokens.spacingVerticalXS, fontSize: tokens.fontSizeBase200 },
+  qualGrid: {
+    display: 'grid',
+    gap: tokens.spacingHorizontalXS,
+    gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
+    maxHeight: '40vh',
+    overflow: 'auto',
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderRadius: tokens.borderRadiusMedium,
+    padding: tokens.spacingHorizontalS,
+  },
+  row: { display: 'flex', gap: tokens.spacingHorizontalS },
+  cellWrap: { whiteSpace: 'normal', wordBreak: 'break-word', overflowWrap: 'anywhere' },
+  availText: { color: tokens.colorNeutralForeground3, fontSize: tokens.fontSizeBase200 },
+});
+
+const useNeedsEditorStyles = makeStyles({
+  grid: {
+    display: 'grid',
+    gridTemplateColumns: '1fr',
+    gap: tokens.spacingHorizontalM,
+    ['@media (min-width: 1024px)']: { gridTemplateColumns: 'repeat(2, 1fr)' },
+    ['@media (min-width: 1280px)']: { gridTemplateColumns: 'repeat(3, 1fr)' },
+  },
+  card: {
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderRadius: tokens.borderRadiusLarge,
+    padding: tokens.spacingHorizontalM,
+    backgroundColor: tokens.colorNeutralBackground1,
+    boxShadow: tokens.shadow2,
+  },
+  roleCard: {
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderRadius: tokens.borderRadiusLarge,
+    padding: tokens.spacingHorizontalM,
+    marginBottom: tokens.spacingVerticalM,
+  },
+  subTitle: { fontWeight: tokens.fontWeightSemibold, marginBottom: tokens.spacingVerticalS },
+  roleGrid: { display: 'grid', gap: tokens.spacingHorizontalS, gridTemplateColumns: 'repeat(auto-fit, minmax(140px, 1fr))', alignItems: 'start' },
+  label: { fontSize: tokens.fontSizeBase200, color: tokens.colorNeutralForeground3, marginBottom: tokens.spacingVerticalXS },
+  content: { overflowY: 'auto', overflowX: 'hidden' },
+  surface: { width: '90vw', maxWidth: '1200px', maxHeight: '85vh' },
+});
+
+const useAppShellStyles = makeStyles({
+  shell: {
+    minHeight: '100vh',
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    maxWidth: '100%',
+    overflow: 'hidden',
+    boxSizing: 'border-box',
+    paddingLeft: '80px',
+    backgroundColor: tokens.colorNeutralBackground1,
+  },
+  contentRow: {
+    display: 'flex',
+    width: '100%',
+    maxWidth: '100%',
+    minHeight: 0,
+    flex: 1,
+    overflow: 'hidden',
+  },
+  main: {
+    flex: 1,
+    minWidth: 0,
+    overflow: 'auto',
+  },
+  mainInner: {
+    padding: tokens.spacingHorizontalM,
+  },
+});
+
 export default function App() {
   // Theme
   const [themeName, setThemeName] = useState<"light" | "dark">(() => {
@@ -1025,11 +1162,7 @@ async function exportShifts() {
     const req = date ? getRequiredFor(date, group.id, role.id, segment) : (all(`SELECT required FROM needs_baseline WHERE group_id=? AND role_id=? AND segment=?`, [group.id, role.id, segment])[0]?.required||0);
     const [val,setVal] = useState<number>(req);
     useEffect(()=>setVal(req),[req]);
-    const useReqStyles = makeStyles({
-      row: { display: 'flex', alignItems: 'center', gap: tokens.spacingHorizontalS },
-      input: { width: '7ch' },
-    });
-    const r = useReqStyles();
+    const r = useRequiredCellStyles();
     return (
       <div className={r.row}>
         <Input
@@ -1046,39 +1179,7 @@ async function exportShifts() {
     );
   }
   function BaselineView(){
-    const useStyles = makeStyles({
-      root: { padding: tokens.spacingHorizontalM },
-      title: { fontWeight: tokens.fontWeightSemibold, fontSize: tokens.fontSizeBase400, marginBottom: tokens.spacingVerticalM },
-      grid: {
-        display: "grid",
-        gridTemplateColumns: "1fr",
-        gap: tokens.spacingHorizontalM,
-        [`@media (min-width: 1024px)`]: { gridTemplateColumns: "repeat(2, 1fr)" },
-        [`@media (min-width: 1280px)`]: { gridTemplateColumns: "repeat(3, 1fr)" },
-      },
-      card: {
-        border: `1px solid ${tokens.colorNeutralStroke2}`,
-        borderRadius: tokens.borderRadiusLarge,
-        padding: tokens.spacingHorizontalM,
-        backgroundColor: tokens.colorNeutralBackground1,
-        boxShadow: tokens.shadow2,
-      },
-      roleCard: {
-        border: `1px solid ${tokens.colorNeutralStroke2}`,
-        borderRadius: tokens.borderRadiusLarge,
-        padding: tokens.spacingHorizontalM,
-        marginBottom: tokens.spacingVerticalM,
-      },
-      roleGrid: {
-        display: "grid",
-        gap: tokens.spacingHorizontalS,
-        gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))",
-        alignItems: 'start',
-      },
-      subTitle: { fontWeight: tokens.fontWeightSemibold, marginBottom: tokens.spacingVerticalS },
-      label: { fontSize: tokens.fontSizeBase200, color: tokens.colorNeutralForeground3, marginBottom: tokens.spacingVerticalXS },
-    });
-    const s = useStyles();
+    const s = useBaselineViewStyles();
     return (
       <div className={s.root}>
         <div className={s.title}>Baseline Needs</div>
@@ -1187,47 +1288,7 @@ function PeopleEditor(){
     closeBulk();
   }
 
-    const useStyles = makeStyles({
-    root: { padding: tokens.spacingHorizontalM },
-    tableWrap: {
-      border: `1px solid ${tokens.colorNeutralStroke2}`,
-      borderRadius: tokens.borderRadiusLarge,
-      overflowY: "auto",
-      overflowX: "hidden",
-      maxHeight: "60vh",
-      width: "100%",
-      boxShadow: tokens.shadow2,
-    },
-    header: { display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: tokens.spacingVerticalS },
-    title: { fontWeight: tokens.fontWeightSemibold, fontSize: tokens.fontSizeBase400 },
-    actions: { display: "flex", gap: tokens.spacingHorizontalS },
-    formGrid: {
-      display: 'grid',
-      gridTemplateColumns: 'repeat(12, 1fr)',
-      gap: tokens.spacingHorizontalS,
-      marginBottom: tokens.spacingVerticalM,
-    },
-    col2: { gridColumn: 'span 2' },
-    col3: { gridColumn: 'span 3' },
-    col4: { gridColumn: 'span 4' },
-    col6: { gridColumn: 'span 6' },
-    centerRow: { display: 'flex', alignItems: 'center' },
-    smallLabel: { color: tokens.colorNeutralForeground3, marginBottom: tokens.spacingVerticalXS, fontSize: tokens.fontSizeBase200 },
-    qualGrid: {
-      display: 'grid',
-      gap: tokens.spacingHorizontalXS,
-      gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
-      maxHeight: '40vh',
-      overflow: 'auto',
-      border: `1px solid ${tokens.colorNeutralStroke2}`,
-      borderRadius: tokens.borderRadiusMedium,
-      padding: tokens.spacingHorizontalS,
-    },
-    row: { display: 'flex', gap: tokens.spacingHorizontalS },
-  cellWrap: { whiteSpace: 'normal', wordBreak: 'break-word', overflowWrap: 'anywhere' },
-  availText: { color: tokens.colorNeutralForeground3, fontSize: tokens.fontSizeBase200 },
-  });
-  const s = useStyles();
+  const s = usePeopleEditorStyles();
 
   return (
     <div className={s.root}>
@@ -1419,29 +1480,7 @@ function PeopleEditor(){
 
   function NeedsEditor(){
     const d = selectedDateObj;
-    const useDialogStyles = makeStyles({
-      grid: {
-        display: "grid",
-        gridTemplateColumns: "1fr",
-        gap: tokens.spacingHorizontalM,
-        [`@media (min-width: 1024px)`]: { gridTemplateColumns: "repeat(2, 1fr)" },
-        [`@media (min-width: 1280px)`]: { gridTemplateColumns: "repeat(3, 1fr)" },
-      },
-      card: {
-        border: `1px solid ${tokens.colorNeutralStroke2}`,
-        borderRadius: tokens.borderRadiusLarge,
-        padding: tokens.spacingHorizontalM,
-        backgroundColor: tokens.colorNeutralBackground1,
-        boxShadow: tokens.shadow2,
-      },
-      roleCard: { border: `1px solid ${tokens.colorNeutralStroke2}`, borderRadius: tokens.borderRadiusLarge, padding: tokens.spacingHorizontalM, marginBottom: tokens.spacingVerticalM },
-      subTitle: { fontWeight: tokens.fontWeightSemibold, marginBottom: tokens.spacingVerticalS },
-      roleGrid: { display: "grid", gap: tokens.spacingHorizontalS, gridTemplateColumns: "repeat(auto-fit, minmax(140px, 1fr))", alignItems: 'start' },
-      label: { fontSize: tokens.fontSizeBase200, color: tokens.colorNeutralForeground3, marginBottom: tokens.spacingVerticalXS },
-      content: { overflowY: 'auto', overflowX: 'hidden' },
-      surface: { width: '90vw', maxWidth: '1200px', maxHeight: '85vh' },
-    });
-    const ds = useDialogStyles();
+    const ds = useNeedsEditorStyles();
     return (
       <Dialog open={showNeedsEditor} onOpenChange={(_, data)=> setShowNeedsEditor(data.open)}>
         <DialogSurface className={ds.surface}>
@@ -1477,36 +1516,6 @@ function PeopleEditor(){
       </Dialog>
     );
   }
-
-  const useAppShellStyles = makeStyles({
-    shell: {
-      minHeight: '100vh',
-      display: 'flex',
-      flexDirection: 'column',
-      width: '100%',
-      maxWidth: '100%',
-      overflow: 'hidden',
-      boxSizing: 'border-box',
-      paddingLeft: '80px',
-      backgroundColor: (themeName === "dark" ? webDarkTheme : webLightTheme).colorNeutralBackground1,
-    },
-    contentRow: {
-      display: 'flex',
-      width: '100%',
-      maxWidth: '100%',
-      minHeight: 0,
-      flex: 1,
-      overflow: 'hidden',
-    },
-    main: {
-      flex: 1,
-      minWidth: 0,
-      overflow: 'auto',
-    },
-    mainInner: {
-      padding: tokens.spacingHorizontalM,
-    },
-  });
   const sh = useAppShellStyles();
 
   return (

--- a/src/components/AdminView.tsx
+++ b/src/components/AdminView.tsx
@@ -20,6 +20,15 @@ import AvailabilityOverrideManager from "./AvailabilityOverrideManager";
 import AutoFillSettings from "./AutoFillSettings";
 import SkillsEditor from "./SkillsEditor";
 
+const useAdminViewStyles = makeStyles({
+  root: {
+    padding: "16px",
+    display: "flex",
+    flexDirection: "column",
+    rowGap: "24px",
+  },
+});
+
 interface AdminViewProps {
   sqlDb: any;
   all: (sql: string, params?: any[]) => any[];
@@ -29,15 +38,7 @@ interface AdminViewProps {
 }
 
 export default function AdminView({ sqlDb, all, run, refresh, segments }: AdminViewProps) {
-  const useStyles = makeStyles({
-    root: {
-      padding: "16px",
-      display: "flex",
-      flexDirection: "column",
-      rowGap: "24px",
-    },
-  });
-  const s = useStyles();
+  const s = useAdminViewStyles();
   const [showOverrides, setShowOverrides] = React.useState(false);
   const [showAutoFillSettings, setShowAutoFillSettings] = React.useState(false);
   return (

--- a/src/components/CrewHistoryView.tsx
+++ b/src/components/CrewHistoryView.tsx
@@ -26,6 +26,102 @@ interface CrewHistoryViewProps {
   all: (sql: string, params?: any[]) => any[];
 }
 
+const NAME_COL_PX = 240;
+const SEG_COL_PX = 160;
+
+const useCrewHistoryViewStyles = makeStyles({
+  root: {
+    padding: `${tokens.spacingVerticalM} ${tokens.spacingHorizontalM}`,
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    maxWidth: '100%',
+    minWidth: 0,
+    overflow: 'hidden',
+    boxSizing: 'border-box',
+    rowGap: tokens.spacingVerticalM,
+  },
+  toolbar: {
+    display: 'grid',
+    gap: tokens.spacingVerticalS,
+    paddingBlockEnd: tokens.spacingVerticalS,
+    minWidth: 0,
+  },
+  controlsGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
+    alignItems: 'stretch',
+    gridAutoRows: 'minmax(40px, auto)',
+    columnGap: tokens.spacingHorizontalS,
+    rowGap: tokens.spacingVerticalS,
+    minWidth: 0,
+  },
+  controlCell: {
+    minWidth: 0,
+    display: 'flex',
+    alignItems: 'end',
+    '& > *': { maxWidth: '100%' },
+  },
+  stack: {
+    display: 'grid',
+    gridAutoRows: 'max-content',
+    rowGap: tokens.spacingVerticalXS,
+    alignItems: 'stretch',
+    minWidth: 0,
+    '& > *': { minWidth: 0 },
+  },
+  full: {
+    width: '100%',
+  },
+  segmentsWrap: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    columnGap: tokens.spacingHorizontalS,
+    rowGap: tokens.spacingVerticalXS,
+    paddingBlockEnd: tokens.spacingVerticalXS,
+    minWidth: 0,
+  },
+  monthRange: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: tokens.spacingHorizontalXS,
+    flexWrap: 'wrap',
+  },
+  label: {
+    fontSize: tokens.fontSizeBase300,
+    color: tokens.colorNeutralForeground2,
+  },
+  scroll: {
+    width: '100%',
+    maxWidth: '100%',
+    minWidth: 0,
+    overflowX: 'auto',
+    overflowY: 'auto',
+    overscrollBehaviorX: 'contain',
+  },
+  stickyName: {
+    position: 'sticky',
+    left: '0px',
+    zIndex: 3,
+    backgroundColor: tokens.colorNeutralBackground1,
+    boxShadow: `inset -1px 0 0 ${tokens.colorNeutralStroke2}`,
+    width: `${NAME_COL_PX}px`,
+    minWidth: `${NAME_COL_PX}px`,
+    maxWidth: `${NAME_COL_PX}px`,
+  },
+  stickySeg: {
+    position: 'sticky',
+    left: `${NAME_COL_PX}px`,
+    zIndex: 2,
+    backgroundColor: tokens.colorNeutralBackground1,
+    boxShadow: `inset -1px 0 0 ${tokens.colorNeutralStroke2}`,
+    width: `${SEG_COL_PX}px`,
+    minWidth: `${SEG_COL_PX}px`,
+    maxWidth: `${SEG_COL_PX}px`,
+  },
+});
+
 export default function CrewHistoryView({
   sqlDb,
   monthlyDefaults,
@@ -37,101 +133,7 @@ export default function CrewHistoryView({
   setMonthlyDefaultForMonth,
   all,
 }: CrewHistoryViewProps) {
-  const NAME_COL_PX = 240;
-  const SEG_COL_PX = 160;
-  const useStyles = makeStyles({
-    root: {
-      padding: `${tokens.spacingVerticalM} ${tokens.spacingHorizontalM}`,
-      display: 'flex',
-      flexDirection: 'column',
-      width: '100%',
-      maxWidth: '100%',
-      minWidth: 0,
-      overflow: 'hidden',
-      boxSizing: 'border-box',
-      rowGap: tokens.spacingVerticalM,
-    },
-    toolbar: {
-      display: 'grid',
-      gap: tokens.spacingVerticalS,
-      paddingBlockEnd: tokens.spacingVerticalS,
-      minWidth: 0,
-    },
-    controlsGrid: {
-      display: 'grid',
-      gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))',
-      alignItems: 'stretch',
-      gridAutoRows: 'minmax(40px, auto)',
-      columnGap: tokens.spacingHorizontalS,
-      rowGap: tokens.spacingVerticalS,
-      minWidth: 0,
-    },
-    controlCell: {
-      minWidth: 0,
-      display: 'flex',
-      alignItems: 'end',
-      '& > *': { maxWidth: '100%' },
-    },
-    stack: {
-      display: 'grid',
-      gridAutoRows: 'max-content',
-      rowGap: tokens.spacingVerticalXS,
-      alignItems: 'stretch',
-      minWidth: 0,
-      '& > *': { minWidth: 0 },
-    },
-    full: {
-      width: '100%',
-    },
-    segmentsWrap: {
-      display: 'flex',
-      flexWrap: 'wrap',
-      alignItems: 'center',
-      columnGap: tokens.spacingHorizontalS,
-      rowGap: tokens.spacingVerticalXS,
-      paddingBlockEnd: tokens.spacingVerticalXS,
-      minWidth: 0,
-    },
-    monthRange: {
-      display: 'flex',
-      alignItems: 'center',
-      gap: tokens.spacingHorizontalXS,
-      flexWrap: 'wrap',
-    },
-    label: {
-      fontSize: tokens.fontSizeBase300,
-      color: tokens.colorNeutralForeground2,
-    },
-    scroll: {
-      width: '100%',
-      maxWidth: '100%',
-      minWidth: 0,
-      overflowX: 'auto',
-      overflowY: 'auto',
-      overscrollBehaviorX: 'contain',
-    },
-    stickyName: {
-      position: 'sticky',
-      left: '0px',
-      zIndex: 3,
-      backgroundColor: tokens.colorNeutralBackground1,
-      boxShadow: `inset -1px 0 0 ${tokens.colorNeutralStroke2}`,
-      width: `${NAME_COL_PX}px`,
-      minWidth: `${NAME_COL_PX}px`,
-      maxWidth: `${NAME_COL_PX}px`,
-    },
-    stickySeg: {
-      position: 'sticky',
-      left: `${NAME_COL_PX}px`,
-      zIndex: 2,
-      backgroundColor: tokens.colorNeutralBackground1,
-      boxShadow: `inset -1px 0 0 ${tokens.colorNeutralStroke2}`,
-      width: `${SEG_COL_PX}px`,
-      minWidth: `${SEG_COL_PX}px`,
-      maxWidth: `${SEG_COL_PX}px`,
-    },
-  });
-  const styles = useStyles();
+  const styles = useCrewHistoryViewStyles();
   // Cache for converting hex colors to CSS styles so we don't recompute for every cell
   const colorStyleCache = useRef<Map<string, React.CSSProperties>>(new Map());
 

--- a/src/components/ExportGroupEditor.tsx
+++ b/src/components/ExportGroupEditor.tsx
@@ -7,6 +7,22 @@ interface ExportGroupEditorProps {
   refresh: () => void;
 }
 
+const useExportGroupEditorStyles = makeStyles({
+  section: { display: "flex", flexDirection: "column", rowGap: tokens.spacingHorizontalS },
+  header: { display: "flex", alignItems: "center", justifyContent: "space-between" },
+  tableWrap: {
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderRadius: tokens.borderRadiusLarge,
+    overflow: "auto",
+    maxHeight: "40vh",
+    width: "100%",
+    boxShadow: tokens.shadow2,
+  },
+  row: { display: "flex", columnGap: tokens.spacingHorizontalS },
+  rightAlign: { textAlign: 'right' },
+  actionsRow: { display: 'flex', gap: tokens.spacingHorizontalS, justifyContent: 'flex-end' },
+});
+
 export default function ExportGroupEditor({ all, run, refresh }: ExportGroupEditorProps) {
   const empty = { group_id: "", code: "", color: "", column_group: "" };
   const [rows, setRows] = useState<any[]>([]);
@@ -76,22 +92,7 @@ export default function ExportGroupEditor({ all, run, refresh }: ExportGroupEdit
     refresh();
   }
 
-  const useStyles = makeStyles({
-    section: { display: "flex", flexDirection: "column", rowGap: tokens.spacingHorizontalS },
-    header: { display: "flex", alignItems: "center", justifyContent: "space-between" },
-    tableWrap: {
-      border: `1px solid ${tokens.colorNeutralStroke2}`,
-      borderRadius: tokens.borderRadiusLarge,
-      overflow: "auto",
-      maxHeight: "40vh",
-      width: "100%",
-      boxShadow: tokens.shadow2,
-    },
-    row: { display: "flex", columnGap: tokens.spacingHorizontalS },
-    rightAlign: { textAlign: 'right' },
-    actionsRow: { display: 'flex', gap: tokens.spacingHorizontalS, justifyContent: 'flex-end' },
-  });
-  const s = useStyles();
+  const s = useExportGroupEditorStyles();
   return (
     <div className={s.section}>
       <div className={s.header}>

--- a/src/components/ExportPreview.tsx
+++ b/src/components/ExportPreview.tsx
@@ -34,6 +34,24 @@ interface ExportPreviewProps {
   roles: any[];
 }
 
+const useExportPreviewStyles = makeStyles({
+  root: { padding: tokens.spacingHorizontalM },
+  controls: {
+    display: "flex",
+    alignItems: "end",
+    gap: tokens.spacingHorizontalM,
+    marginBottom: tokens.spacingVerticalM,
+  },
+  spacer: { marginLeft: "auto" },
+  tableWrapper: {
+    overflow: "auto",
+    maxHeight: "60vh",
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderRadius: tokens.borderRadiusMedium,
+  },
+  rowsText: { color: tokens.colorNeutralForeground3, marginTop: tokens.spacingVerticalXS },
+});
+
 export default function ExportPreview({
   sqlDb,
   exportStart,
@@ -49,24 +67,7 @@ export default function ExportPreview({
   people,
   roles,
 }: ExportPreviewProps) {
-  const useStyles = makeStyles({
-    root: { padding: tokens.spacingHorizontalM },
-    controls: {
-      display: "flex",
-      alignItems: "end",
-      gap: tokens.spacingHorizontalM,
-      marginBottom: tokens.spacingVerticalM,
-    },
-    spacer: { marginLeft: "auto" },
-    tableWrapper: {
-      overflow: "auto",
-      maxHeight: "60vh",
-      border: `1px solid ${tokens.colorNeutralStroke2}`,
-      borderRadius: tokens.borderRadiusMedium,
-    },
-    rowsText: { color: tokens.colorNeutralForeground3, marginTop: tokens.spacingVerticalXS },
-  });
-  const s = useStyles();
+  const s = useExportPreviewStyles();
   function pad2(n: number) {
     return n < 10 ? `0${n}` : `${n}`;
   }

--- a/src/components/GroupEditor.tsx
+++ b/src/components/GroupEditor.tsx
@@ -7,36 +7,37 @@ interface GroupEditorProps {
   refresh: () => void;
 }
 
+const useGroupEditorStyles = makeStyles({
+  root: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: tokens.spacingVerticalM,
+  },
+  headerBar: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  tableWrap: {
+    borderRadius: tokens.borderRadiusMedium,
+    boxShadow: tokens.shadow4,
+    overflow: 'auto',
+    maxHeight: '40vh',
+    width: '100%',
+  },
+  formSection: {
+    display: 'flex',
+    flexDirection: 'column',
+    rowGap: tokens.spacingVerticalS,
+  },
+  actionRow: {
+    display: 'flex',
+    columnGap: tokens.spacingHorizontalS,
+  },
+});
+
 export default function GroupEditor({ all, run, refresh }: GroupEditorProps) {
-  const useStyles = makeStyles({
-    root: {
-      display: 'flex',
-      flexDirection: 'column',
-      rowGap: tokens.spacingVerticalM,
-    },
-    headerBar: {
-      display: 'flex',
-      justifyContent: 'space-between',
-      alignItems: 'center',
-    },
-    tableWrap: {
-      borderRadius: tokens.borderRadiusMedium,
-      boxShadow: tokens.shadow4,
-      overflow: 'auto',
-      maxHeight: '40vh',
-      width: '100%',
-    },
-    formSection: {
-      display: 'flex',
-      flexDirection: 'column',
-      rowGap: tokens.spacingVerticalS,
-    },
-    actionRow: {
-      display: 'flex',
-      columnGap: tokens.spacingHorizontalS,
-    },
-  });
-  const styles = useStyles();
+  const styles = useGroupEditorStyles();
   const empty = { name: "", theme: "", custom_color: "" };
   const [groups, setGroups] = useState<any[]>([]);
   const [editing, setEditing] = useState<any | null>(null);

--- a/src/components/RoleEditor.tsx
+++ b/src/components/RoleEditor.tsx
@@ -9,6 +9,22 @@ interface RoleEditorProps {
   segments: SegmentRow[];
 }
 
+const useRoleEditorStyles = makeStyles({
+  section: { display: "flex", flexDirection: "column", rowGap: tokens.spacingHorizontalS },
+  header: { display: "flex", alignItems: "center", justifyContent: "space-between" },
+  tableWrap: {
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderRadius: tokens.borderRadiusLarge,
+    overflow: "auto",
+    maxHeight: "40vh",
+    width: "100%",
+    boxShadow: tokens.shadow2,
+  },
+  row: { display: "flex", columnGap: tokens.spacingHorizontalS, flexWrap: "wrap" },
+  rightAlign: { textAlign: 'right' },
+  actionsRow: { display: 'flex', gap: tokens.spacingHorizontalS, justifyContent: 'flex-end' },
+});
+
 export default function RoleEditor({ all, run, refresh, segments }: RoleEditorProps) {
   const [roles, setRoles] = useState<any[]>([]);
   const [groups, setGroups] = useState<any[]>([]);
@@ -76,22 +92,7 @@ export default function RoleEditor({ all, run, refresh, segments }: RoleEditorPr
     refresh();
   }
 
-  const useStyles = makeStyles({
-    section: { display: "flex", flexDirection: "column", rowGap: tokens.spacingHorizontalS },
-    header: { display: "flex", alignItems: "center", justifyContent: "space-between" },
-    tableWrap: {
-      border: `1px solid ${tokens.colorNeutralStroke2}`,
-      borderRadius: tokens.borderRadiusLarge,
-      overflow: "auto",
-      maxHeight: "40vh",
-      width: "100%",
-      boxShadow: tokens.shadow2,
-    },
-    row: { display: "flex", columnGap: tokens.spacingHorizontalS, flexWrap: "wrap" },
-    rightAlign: { textAlign: 'right' },
-    actionsRow: { display: 'flex', gap: tokens.spacingHorizontalS, justifyContent: 'flex-end' },
-  });
-  const s = useStyles();
+  const s = useRoleEditorStyles();
   return (
     <div className={s.section}>
       <div className={s.header}>

--- a/src/components/SegmentAdjustmentEditor.tsx
+++ b/src/components/SegmentAdjustmentEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
 import {
   Button,
   Field,
@@ -38,6 +38,28 @@ const mins = (t: string) => {
 };
 const pad2 = (n: number) => String(n).padStart(2, "0");
 const fmt = (m: number) => `${pad2(Math.floor(m / 60))}:${pad2(m % 60)}`;
+
+const useSegmentAdjustmentStyles = makeStyles({
+  section: { display: "flex", flexDirection: "column", rowGap: tokens.spacingHorizontalS },
+  header: { display: "flex", alignItems: "center", justifyContent: "space-between" },
+  tableWrap: {
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderRadius: tokens.borderRadiusLarge,
+    overflow: "auto",
+    maxHeight: "40vh",
+    width: "100%",
+    boxShadow: tokens.shadow2,
+  },
+  row: { display: "flex", columnGap: tokens.spacingHorizontalS },
+  flex1: { flex: 1 },
+  actionsRow: { display: "flex", gap: tokens.spacingHorizontalS, justifyContent: "flex-end" },
+  number: { width: "12ch" },
+  previewWrap: { display: "flex", flexDirection: "column", rowGap: tokens.spacingVerticalXS, marginTop: tokens.spacingVerticalS },
+  timeline: { position: "relative", height: 8, background: tokens.colorNeutralBackground5, borderRadius: tokens.borderRadiusSmall },
+  condBar: { position: "absolute", top: 0, bottom: 0, background: tokens.colorNeutralForeground3, opacity: 0.3 },
+  targetBar: { position: "absolute", top: 0, bottom: 0, background: tokens.colorNeutralForeground2, opacity: 0.4 },
+  adjustedBar: { position: "absolute", top: 0, bottom: 0, background: tokens.colorBrandBackground },
+});
 
 export default function SegmentAdjustmentEditor({ all, run, refresh, segments }: Props) {
   const empty: Omit<SegmentAdjustmentRow, "id"> = {
@@ -170,28 +192,7 @@ export default function SegmentAdjustmentEditor({ all, run, refresh, segments }:
     refresh();
   }
 
-  const useStyles = makeStyles({
-    section: { display: "flex", flexDirection: "column", rowGap: tokens.spacingHorizontalS },
-    header: { display: "flex", alignItems: "center", justifyContent: "space-between" },
-    tableWrap: {
-      border: `1px solid ${tokens.colorNeutralStroke2}`,
-      borderRadius: tokens.borderRadiusLarge,
-      overflow: "auto",
-      maxHeight: "40vh",
-      width: "100%",
-      boxShadow: tokens.shadow2,
-    },
-    row: { display: "flex", columnGap: tokens.spacingHorizontalS },
-    flex1: { flex: 1 },
-    actionsRow: { display: "flex", gap: tokens.spacingHorizontalS, justifyContent: "flex-end" },
-    number: { width: "12ch" },
-    previewWrap: { display: "flex", flexDirection: "column", rowGap: tokens.spacingVerticalXS, marginTop: tokens.spacingVerticalS },
-    timeline: { position: "relative", height: 8, background: tokens.colorNeutralBackground5, borderRadius: tokens.borderRadiusSmall },
-    condBar: { position: "absolute", top: 0, bottom: 0, background: tokens.colorNeutralForeground3, opacity: 0.3 },
-    targetBar: { position: "absolute", top: 0, bottom: 0, background: tokens.colorNeutralForeground2, opacity: 0.4 },
-    adjustedBar: { position: "absolute", top: 0, bottom: 0, background: tokens.colorBrandBackground },
-  });
-  const s = useStyles();
+  const s = useSegmentAdjustmentStyles();
 
   return (
     <div className={s.section}>

--- a/src/components/SegmentEditor.tsx
+++ b/src/components/SegmentEditor.tsx
@@ -7,6 +7,24 @@ interface SegmentEditorProps {
   refresh: () => void;
 }
 
+const useSegmentEditorStyles = makeStyles({
+  section: { display: "flex", flexDirection: "column", rowGap: tokens.spacingHorizontalS },
+  header: { display: "flex", alignItems: "center", justifyContent: "space-between" },
+  tableWrap: {
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderRadius: tokens.borderRadiusLarge,
+    overflow: "auto",
+    maxHeight: "40vh",
+    width: "100%",
+    boxShadow: tokens.shadow2,
+  },
+  row: { display: "flex", columnGap: tokens.spacingHorizontalS },
+  rightAlign: { textAlign: 'right' },
+  flex1: { flex: 1 },
+  orderWidth: { width: '10ch' },
+  actionsRow: { display: 'flex', gap: tokens.spacingHorizontalS, justifyContent: 'flex-end' },
+});
+
 export default function SegmentEditor({ all, run, refresh }: SegmentEditorProps) {
   const empty = { name: "", start_time: "", end_time: "", ordering: 0 };
   const [segments, setSegments] = useState<any[]>([]);
@@ -66,24 +84,7 @@ export default function SegmentEditor({ all, run, refresh }: SegmentEditorProps)
     refresh();
   }
 
-  const useStyles = makeStyles({
-    section: { display: "flex", flexDirection: "column", rowGap: tokens.spacingHorizontalS },
-    header: { display: "flex", alignItems: "center", justifyContent: "space-between" },
-    tableWrap: {
-      border: `1px solid ${tokens.colorNeutralStroke2}`,
-      borderRadius: tokens.borderRadiusLarge,
-      overflow: "auto",
-      maxHeight: "40vh",
-      width: "100%",
-      boxShadow: tokens.shadow2,
-    },
-    row: { display: "flex", columnGap: tokens.spacingHorizontalS },
-    rightAlign: { textAlign: 'right' },
-    flex1: { flex: 1 },
-    orderWidth: { width: '10ch' },
-    actionsRow: { display: 'flex', gap: tokens.spacingHorizontalS, justifyContent: 'flex-end' },
-  });
-  const s = useStyles();
+  const s = useSegmentEditorStyles();
   return (
     <div className={s.section}>
       <div className={s.header}>

--- a/src/components/SkillsEditor.tsx
+++ b/src/components/SkillsEditor.tsx
@@ -10,18 +10,19 @@ interface SkillsEditorProps {
 type SkillRow = { id: number; code: string; name: string; active: number; ordering: number | null; group_id: number | null; group_name: string | null };
 type GroupRow = { id: number; name: string };
 
+const useSkillsEditorStyles = makeStyles({
+  root: { display: 'grid', gap: tokens.spacingVerticalS },
+  row: { display: 'flex', gap: tokens.spacingHorizontalS, alignItems: 'center', flexWrap: 'wrap' },
+  tableWrap: { overflow: 'auto', border: `1px solid ${tokens.colorNeutralStroke2}`, borderRadius: tokens.borderRadiusLarge },
+  code: { width: '140px' },
+  name: { minWidth: '240px', flex: 1 },
+  groupSel: { width: '220px' },
+  actions: { display: 'flex', gap: tokens.spacingHorizontalS },
+  header: { fontWeight: tokens.fontWeightSemibold },
+});
+
 export default function SkillsEditor({ all, run, refresh }: SkillsEditorProps) {
-  const useStyles = makeStyles({
-    root: { display: 'grid', gap: tokens.spacingVerticalS },
-    row: { display: 'flex', gap: tokens.spacingHorizontalS, alignItems: 'center', flexWrap: 'wrap' },
-    tableWrap: { overflow: 'auto', border: `1px solid ${tokens.colorNeutralStroke2}`, borderRadius: tokens.borderRadiusLarge },
-    code: { width: '140px' },
-    name: { minWidth: '240px', flex: 1 },
-    groupSel: { width: '220px' },
-    actions: { display: 'flex', gap: tokens.spacingHorizontalS },
-    header: { fontWeight: tokens.fontWeightSemibold },
-  });
-  const s = useStyles();
+  const s = useSkillsEditorStyles();
 
   const [rows, setRows] = React.useState<SkillRow[]>([]);
   const [code, setCode] = React.useState("");

--- a/src/components/Training.tsx
+++ b/src/components/Training.tsx
@@ -79,6 +79,229 @@ const viewTabs = [
   { key: "qualities", label: "Qualities" },
 ] as const;
 
+const useTrainingStyles = makeStyles({
+  root: {
+    padding: tokens.spacingHorizontalM,
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalM,
+  },
+  header: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: tokens.spacingHorizontalM,
+    justifyContent: "space-between",
+    alignItems: "flex-start",
+  },
+  titleArea: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalXS,
+  },
+  title: {
+    fontWeight: tokens.fontWeightSemibold,
+    fontSize: tokens.fontSizeBase500,
+  },
+  subtitle: {
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase200,
+  },
+  tabList: {
+    marginLeft: "auto",
+  },
+  filters: {
+    display: "flex",
+    gap: tokens.spacingHorizontalS,
+    alignItems: "stretch",
+    flexWrap: "wrap",
+    width: "100%",
+  },
+  groupCell: {
+    display: "grid",
+    gap: tokens.spacingHorizontalXS,
+    minWidth: "220px",
+  },
+  grow: { flex: 1, minWidth: "260px" },
+  tableWrap: {
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    borderRadius: tokens.borderRadiusLarge,
+    overflow: "auto",
+    maxHeight: "60vh",
+    width: "100%",
+    boxShadow: tokens.shadow2,
+    backgroundColor: tokens.colorNeutralBackground1,
+  },
+  table: { width: "100%", borderCollapse: "separate", borderSpacing: 0 },
+  headerCell: {
+    padding: tokens.spacingHorizontalS,
+    textAlign: "center",
+    backgroundColor: tokens.colorNeutralBackground2,
+    position: "sticky",
+    top: 0,
+    zIndex: 1,
+  },
+  personCol: {
+    position: "sticky",
+    left: 0,
+    backgroundColor: tokens.colorNeutralBackground1,
+    textAlign: "left",
+    minWidth: "220px",
+    maxWidth: "260px",
+    width: "240px",
+    boxShadow: `1px 0 0 ${tokens.colorNeutralStroke2}`,
+  },
+  skillCol: { minWidth: "80px", width: "80px" },
+  cell: { padding: tokens.spacingHorizontalS, textAlign: "center" },
+  cellDropdown: { width: "60px" },
+  dashboard: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalL,
+    paddingBottom: tokens.spacingVerticalL,
+  },
+  metricGrid: {
+    display: "grid",
+    gap: tokens.spacingHorizontalM,
+    gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
+  },
+  metricCard: {
+    height: "100%",
+    backgroundColor: tokens.colorNeutralBackground2,
+  },
+  metricValue: {
+    fontSize: tokens.fontSizeHero700,
+    fontWeight: tokens.fontWeightSemibold,
+    color: tokens.colorNeutralForeground1,
+  },
+  metricCaption: {
+    color: tokens.colorNeutralForeground3,
+  },
+  sectionsGrid: {
+    display: "grid",
+    gap: tokens.spacingHorizontalM,
+    gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
+  },
+  section: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalM,
+    backgroundColor: tokens.colorNeutralBackground1,
+    borderRadius: tokens.borderRadiusLarge,
+    padding: tokens.spacingHorizontalM,
+    boxShadow: tokens.shadow2,
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+    minHeight: "220px",
+  },
+  sectionHeader: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalXS,
+  },
+  sectionDescription: {
+    color: tokens.colorNeutralForeground3,
+  },
+  focusItem: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalS,
+    padding: `${tokens.spacingVerticalXS} 0`,
+    borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+  },
+  focusItemLast: {
+    borderBottom: "none",
+    paddingBottom: 0,
+  },
+  focusHeader: {
+    display: "flex",
+    justifyContent: "space-between",
+    gap: tokens.spacingHorizontalS,
+    flexWrap: "wrap",
+  },
+  focusMeta: {
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase200,
+  },
+  bar: {
+    display: "flex",
+    width: "100%",
+    height: "12px",
+    borderRadius: tokens.borderRadiusMedium,
+    overflow: "hidden",
+    backgroundColor: tokens.colorNeutralBackground3,
+    boxShadow: `inset 0 0 0 1px ${tokens.colorNeutralStroke2}`,
+  },
+  barSegment: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    color: tokens.colorNeutralForegroundInverted,
+    fontSize: tokens.fontSizeBase100,
+    fontWeight: tokens.fontWeightSemibold,
+    lineHeight: "1",
+  },
+  barSegmentMuted: {
+    backgroundColor: tokens.colorNeutralBackground4,
+    color: tokens.colorNeutralForeground3,
+  },
+  focusFooter: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    flexWrap: "wrap",
+    gap: tokens.spacingHorizontalS,
+  },
+  legend: {
+    display: "flex",
+    gap: tokens.spacingHorizontalS,
+    flexWrap: "wrap",
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground3,
+  },
+  legendDot: {
+    width: "8px",
+    height: "8px",
+    borderRadius: tokens.borderRadiusCircular,
+    display: "inline-block",
+  },
+  personCard: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalXS,
+    padding: tokens.spacingHorizontalM,
+    borderRadius: tokens.borderRadiusMedium,
+    backgroundColor: tokens.colorNeutralBackground2,
+    border: `1px solid ${tokens.colorNeutralStroke2}`,
+  },
+  personName: {
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  personMeta: {
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase200,
+  },
+  personBadgeRow: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    flexWrap: "wrap",
+    gap: tokens.spacingHorizontalS,
+  },
+  personGrid: {
+    display: "grid",
+    gap: tokens.spacingHorizontalM,
+    gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+  },
+  personColumnTitle: {
+    fontWeight: tokens.fontWeightSemibold,
+    color: tokens.colorNeutralForeground2,
+  },
+  emptyState: {
+    color: tokens.colorNeutralForeground3,
+    fontSize: tokens.fontSizeBase200,
+    padding: tokens.spacingHorizontalM,
+  },
+});
+
 export default function Training({
   people,
   roles,
@@ -181,229 +404,7 @@ export default function Training({
     }
   }
 
-  const useStyles = makeStyles({
-    root: {
-      padding: tokens.spacingHorizontalM,
-      display: "flex",
-      flexDirection: "column",
-      gap: tokens.spacingVerticalM,
-    },
-    header: {
-      display: "flex",
-      flexWrap: "wrap",
-      gap: tokens.spacingHorizontalM,
-      justifyContent: "space-between",
-      alignItems: "flex-start",
-    },
-    titleArea: {
-      display: "flex",
-      flexDirection: "column",
-      gap: tokens.spacingVerticalXS,
-    },
-    title: {
-      fontWeight: tokens.fontWeightSemibold,
-      fontSize: tokens.fontSizeBase500,
-    },
-    subtitle: {
-      color: tokens.colorNeutralForeground3,
-      fontSize: tokens.fontSizeBase200,
-    },
-    tabList: {
-      marginLeft: "auto",
-    },
-    filters: {
-      display: "flex",
-      gap: tokens.spacingHorizontalS,
-      alignItems: "stretch",
-      flexWrap: "wrap",
-      width: "100%",
-    },
-    groupCell: {
-      display: "grid",
-      gap: tokens.spacingHorizontalXS,
-      minWidth: "220px",
-    },
-    grow: { flex: 1, minWidth: "260px" },
-    tableWrap: {
-      border: `1px solid ${tokens.colorNeutralStroke2}`,
-      borderRadius: tokens.borderRadiusLarge,
-      overflow: "auto",
-      maxHeight: "60vh",
-      width: "100%",
-      boxShadow: tokens.shadow2,
-      backgroundColor: tokens.colorNeutralBackground1,
-    },
-    table: { width: "100%", borderCollapse: "separate", borderSpacing: 0 },
-    headerCell: {
-      padding: tokens.spacingHorizontalS,
-      textAlign: "center",
-      backgroundColor: tokens.colorNeutralBackground2,
-      position: "sticky",
-      top: 0,
-      zIndex: 1,
-    },
-    personCol: {
-      position: "sticky",
-      left: 0,
-      backgroundColor: tokens.colorNeutralBackground1,
-      textAlign: "left",
-      minWidth: "220px",
-      maxWidth: "260px",
-      width: "240px",
-      boxShadow: `1px 0 0 ${tokens.colorNeutralStroke2}`,
-    },
-    skillCol: { minWidth: "80px", width: "80px" },
-    cell: { padding: tokens.spacingHorizontalS, textAlign: "center" },
-    cellDropdown: { width: "60px" },
-    dashboard: {
-      display: "flex",
-      flexDirection: "column",
-      gap: tokens.spacingVerticalL,
-      paddingBottom: tokens.spacingVerticalL,
-    },
-    metricGrid: {
-      display: "grid",
-      gap: tokens.spacingHorizontalM,
-      gridTemplateColumns: "repeat(auto-fit, minmax(180px, 1fr))",
-    },
-    metricCard: {
-      height: "100%",
-      backgroundColor: tokens.colorNeutralBackground2,
-    },
-    metricValue: {
-      fontSize: tokens.fontSizeHero700,
-      fontWeight: tokens.fontWeightSemibold,
-      color: tokens.colorNeutralForeground1,
-    },
-    metricCaption: {
-      color: tokens.colorNeutralForeground3,
-    },
-    sectionsGrid: {
-      display: "grid",
-      gap: tokens.spacingHorizontalM,
-      gridTemplateColumns: "repeat(auto-fit, minmax(280px, 1fr))",
-    },
-    section: {
-      display: "flex",
-      flexDirection: "column",
-      gap: tokens.spacingVerticalM,
-      backgroundColor: tokens.colorNeutralBackground1,
-      borderRadius: tokens.borderRadiusLarge,
-      padding: tokens.spacingHorizontalM,
-      boxShadow: tokens.shadow2,
-      border: `1px solid ${tokens.colorNeutralStroke2}`,
-      minHeight: "220px",
-    },
-    sectionHeader: {
-      display: "flex",
-      flexDirection: "column",
-      gap: tokens.spacingVerticalXS,
-    },
-    sectionDescription: {
-      color: tokens.colorNeutralForeground3,
-    },
-    focusItem: {
-      display: "flex",
-      flexDirection: "column",
-      gap: tokens.spacingVerticalS,
-      padding: `${tokens.spacingVerticalXS} 0`,
-      borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
-    },
-    focusItemLast: {
-      borderBottom: "none",
-      paddingBottom: 0,
-    },
-    focusHeader: {
-      display: "flex",
-      justifyContent: "space-between",
-      gap: tokens.spacingHorizontalS,
-      flexWrap: "wrap",
-    },
-    focusMeta: {
-      color: tokens.colorNeutralForeground3,
-      fontSize: tokens.fontSizeBase200,
-    },
-    bar: {
-      display: "flex",
-      width: "100%",
-      height: "12px",
-      borderRadius: tokens.borderRadiusMedium,
-      overflow: "hidden",
-      backgroundColor: tokens.colorNeutralBackground3,
-      boxShadow: `inset 0 0 0 1px ${tokens.colorNeutralStroke2}`,
-    },
-    barSegment: {
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "center",
-      color: tokens.colorNeutralForegroundInverted,
-      fontSize: tokens.fontSizeBase100,
-      fontWeight: tokens.fontWeightSemibold,
-      lineHeight: "1",
-    },
-    barSegmentMuted: {
-      backgroundColor: tokens.colorNeutralBackground4,
-      color: tokens.colorNeutralForeground3,
-    },
-    focusFooter: {
-      display: "flex",
-      justifyContent: "space-between",
-      alignItems: "center",
-      flexWrap: "wrap",
-      gap: tokens.spacingHorizontalS,
-    },
-    legend: {
-      display: "flex",
-      gap: tokens.spacingHorizontalS,
-      flexWrap: "wrap",
-      fontSize: tokens.fontSizeBase200,
-      color: tokens.colorNeutralForeground3,
-    },
-    legendDot: {
-      width: "8px",
-      height: "8px",
-      borderRadius: tokens.borderRadiusCircular,
-      display: "inline-block",
-    },
-    personCard: {
-      display: "flex",
-      flexDirection: "column",
-      gap: tokens.spacingVerticalXS,
-      padding: tokens.spacingHorizontalM,
-      borderRadius: tokens.borderRadiusMedium,
-      backgroundColor: tokens.colorNeutralBackground2,
-      border: `1px solid ${tokens.colorNeutralStroke2}`,
-    },
-    personName: {
-      fontWeight: tokens.fontWeightSemibold,
-    },
-    personMeta: {
-      color: tokens.colorNeutralForeground3,
-      fontSize: tokens.fontSizeBase200,
-    },
-    personBadgeRow: {
-      display: "flex",
-      justifyContent: "space-between",
-      alignItems: "center",
-      flexWrap: "wrap",
-      gap: tokens.spacingHorizontalS,
-    },
-    personGrid: {
-      display: "grid",
-      gap: tokens.spacingHorizontalM,
-      gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
-    },
-    personColumnTitle: {
-      fontWeight: tokens.fontWeightSemibold,
-      color: tokens.colorNeutralForeground2,
-    },
-    emptyState: {
-      color: tokens.colorNeutralForeground3,
-      fontSize: tokens.fontSizeBase200,
-      padding: tokens.spacingHorizontalM,
-    },
-  });
-  const s = useStyles();
+  const s = useTrainingStyles();
 
   const filteredPeople = useMemo(() => filterPeopleList(people, filters), [people, filters]);
   const filteredRoles = roles.filter((r: any) => !groupId || r.group_id === groupId);


### PR DESCRIPTION
## Summary
- hoist Fluent UI `makeStyles` definitions to module scope for Admin tooling components and App internals
- reuse the new hooks across Admin sub-editors, the People editor, Needs editor, and shell layout
- add the missing `useMemo` import in `SegmentAdjustmentEditor` to keep hooks working

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9dfbb95108322a91c68b722388447